### PR TITLE
Optimized DecimalSerializer

### DIFF
--- a/Wire.PerfTest/Program.cs
+++ b/Wire.PerfTest/Program.cs
@@ -24,13 +24,17 @@ namespace Wire.PerfTest
             //SerializePocoAkka();
             //Console.WriteLine();
             //Console.WriteLine("Running hot");
+            start:
             SerializePocoVersionInteolerant();
             //SerializePocoProtoBufNet();
             SerializePoco();
             //SerializePocoJsonNet();
             //SerializePocoBinaryFormatter();
             //SerializePocoAkka();
+            TestSerializerSingleValues();
+            Console.WriteLine("Press ENTER to repeat.");
             Console.ReadLine();
+            goto start;
         }
 
         private static Poco poco = new Poco
@@ -38,6 +42,38 @@ namespace Wire.PerfTest
             Age = 123,
             Name = "Hello"
         };
+
+        private static void TestSerializerSingleValues()
+        {
+            Console.WriteLine("");
+            Console.WriteLine("Testing individual ValueSerializers.");
+            var serializer = new Serializer(new SerializerOptions(false));
+            var stream = new MemoryStream(4096);
+            Action<object> testSerialize = o =>
+            {
+                Console.Write("{0}: ", o.GetType().Name);
+                Stopwatch sw = Stopwatch.StartNew();
+                for (int i = 0; i < 1000000; i++)
+                {
+                    serializer.Serialize(o, stream);
+                    stream.Position = 0;
+                }
+                sw.Stop();
+                Console.WriteLine((double)sw.ElapsedTicks / 1000000);
+            };
+            testSerialize((short)1234);
+            testSerialize(12345679);
+            testSerialize(123456789L);
+            testSerialize(123.45f);
+            testSerialize(123.45);
+            testSerialize(123.45m);
+            testSerialize(DateTime.UtcNow);
+            testSerialize(new[] { 'a' });
+            testSerialize(new byte[] { 0 });
+            testSerialize("1");
+            testSerialize(new Poco { Name = "a" });
+            testSerialize(new Poco { Name = (string)null });
+        }
 
         private static void SerializePocoJsonNet()
         {

--- a/Wire/ValueSerializers/DecimalSerializer.cs
+++ b/Wire/ValueSerializers/DecimalSerializer.cs
@@ -16,12 +16,21 @@ namespace Wire.ValueSerializers
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
             var data = decimal.GetBits((decimal) value);
-            ConsistentArraySerializer.Instance.WriteValue(stream,data,session);
+            Int32Serializer.Instance.WriteValue(stream, (object)data[0], session);
+            Int32Serializer.Instance.WriteValue(stream, (object)data[1], session);
+            Int32Serializer.Instance.WriteValue(stream, (object)data[2], session);
+            Int32Serializer.Instance.WriteValue(stream, (object)data[3], session);
         }
 
         public override object ReadValue(Stream stream, SerializerSession session)
         {
-            var parts = (int[])ConsistentArraySerializer.Instance.ReadValue(stream, session);
+            var parts = new[]
+                {
+                    (int)Int32Serializer.Instance.ReadValue(stream, session),
+                    (int)Int32Serializer.Instance.ReadValue(stream, session),
+                    (int)Int32Serializer.Instance.ReadValue(stream, session),
+                    (int)Int32Serializer.Instance.ReadValue(stream, session),
+                };
             bool sign = (parts[3] & 0x80000000) != 0;
 
             byte scale = (byte)((parts[3] >> 16) & 0x7F);


### PR DESCRIPTION
I simply couldn't resist the urge to performance test and hack at this project :)

When testing the ValueSerializers separately, I found that the DecimalSerializer was significantly slower than all others, because it is using the ConsistentArraySerializer which is the slowest of all serializers. This PR changes the DecimalSerializer to directly write 4 Int32 values instead of writing it as an array.

Performance for serializing a decimal on my machine increased from ~2.12 ticks / serialization to ~0.65 ticks / serialization, a more than 3x increase!
