### PR TITLE
Add TypeResolver

### DIFF
--- a/Wire.Tests/CustomObjectTests.cs
+++ b/Wire.Tests/CustomObjectTests.cs
@@ -107,5 +107,15 @@ namespace Wire.Tests
             var actual = Deserialize<Tuple<string>>();
             Assert.AreEqual(expected,actual);
         }
+
+        [TestMethod]
+        public void CanSerializeType()
+        {
+            var expected = Tuple.Create(GetType(), GetType(), (Type)null);
+            Serialize(expected);
+            Reset();
+            var actual = Deserialize<Tuple<Type, Type, Type>>();
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/Wire.Tests/CustomTypeResolverTest.cs
+++ b/Wire.Tests/CustomTypeResolverTest.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Wire.ValueSerializers;
+
+namespace Wire.Tests
+{
+    class CustomTypeResolver : ITypeResolver
+    {
+        private static byte[] GetManifestNameFromType(Type type)
+        {
+            var typeName = "@" + type.AssemblyQualifiedName + "@";
+            var typeNameBytes = Encoding.UTF8.GetBytes(typeName);
+            return new[] { ObjectSerializer.ManifestFull }
+                .Concat(BitConverter.GetBytes(typeNameBytes.Length))
+                .Concat(typeNameBytes)
+                .ToArray(); //serializer id 255 + @ + assembly qualified name + @
+        }
+
+        private static Type GetTypeFromManifestName(Stream stream, DeserializerSession session)
+        {
+            var bytes = (byte[])ByteArraySerializer.Instance.ReadValue(stream, session);
+            var typeName = Encoding.UTF8.GetString(bytes);
+            if (typeName[0] != '@' || typeName[typeName.Length - 1] != '@')
+                throw new TypeLoadException("Invalid type name: " + typeName);
+            return Type.GetType(typeName.Substring(1, typeName.Length - 2), true);
+        }
+
+        public void WriteType(Stream stream, Type type, SerializerSession session)
+        {
+            if (session.ShouldWriteTypeManifest(type))
+            {
+                stream.Write(GetManifestNameFromType(type));
+            }
+            else
+            {
+                var typeIdentifier = session.GetTypeIdentifier(type);
+                stream.Write(new[] { ObjectSerializer.ManifestIndex });
+                stream.WriteUInt16((ushort)typeIdentifier);
+            }
+        }
+
+        public Type ReadType(Stream stream, int firstManifest, DeserializerSession session)
+        {
+            if (firstManifest == ObjectSerializer.ManifestFull)
+            {
+                var type = GetTypeFromManifestName(stream, session);
+                session.TrackDeserializedType(type);
+                return type;
+            }
+            else
+            {
+                var typeId = stream.ReadUInt16(session);
+                var type = session.GetTypeFromTypeId(typeId);
+                return type;
+            }
+        }
+    }
+
+    [TestClass]
+    public class CustomTypeResolverTest
+    {
+        private Serializer serializer;
+        private MemoryStream stream;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            var option = new SerializerOptions(typeResolver: new CustomTypeResolver());
+            serializer = new Serializer(option);
+            stream = new MemoryStream();
+        }
+
+        public void Reset()
+        {
+            stream.Position = 0;
+        }
+
+        public void Serialize(object o)
+        {
+            serializer.Serialize(o, stream);
+        }
+
+        public T Deserialize<T>()
+        {
+            return serializer.Deserialize<T>(stream);
+        }
+
+        [TestMethod]
+        public void CanSerializePolymorphicObjectWithCustomTypeResolver()
+        {
+            var expected = new Something
+            {
+                Else = new OtherElse
+                {
+                    Name = "Foo",
+                    More = "Bar"
+                }
+            };
+            Serialize(expected);
+            Reset();
+            var actual = Deserialize<Something>();
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void CanSerializeObjectWithCustomTypeResolver()
+        {
+            var expected = new Something
+            {
+                BoolProp = true,
+                Int32Prop = 123,
+                NullableInt32PropHasValue = 888,
+                StringProp = "hello"
+            };
+
+
+            Serialize(expected);
+            Reset();
+            var actual = Deserialize<Something>();
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void CanSerializeTypeWithCustomTypeResolver()
+        {
+            var expected = Tuple.Create(GetType(), GetType(), (Type)null);
+            Serialize(expected);
+            Reset();
+            var actual = Deserialize<Tuple<Type, Type, Type>>();
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/Wire.Tests/Wire.Tests.csproj
+++ b/Wire.Tests/Wire.Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Bugs.cs" />
     <Compile Include="CollectionTests.cs" />
     <Compile Include="CustomObjectTests.cs" />
+    <Compile Include="CustomTypeResolverTest.cs" />
     <Compile Include="CyclicTests.cs" />
     <Compile Include="FSharpTests.cs" />
     <Compile Include="ImmutableCollectionsTests.cs" />

--- a/Wire/DefaultTypeResolver.cs
+++ b/Wire/DefaultTypeResolver.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Wire.ValueSerializers;
+
+namespace Wire
+{
+    public class DefaultTypeResolver : ITypeResolver
+    {
+        private static readonly ConcurrentDictionary<Type, byte[]> Type2NameMap =
+            new ConcurrentDictionary<Type, byte[]>();
+
+        private static readonly ConcurrentDictionary<byte[], Type> Name2TypeMap =
+            new ConcurrentDictionary<byte[], Type>(new ByteArrayEqualityComparer());
+
+        private static byte[] GetManifestNameFromType(Type type)
+        {
+            return Type2NameMap.GetOrAdd(type, t =>
+            {
+                var typeName = type.GetShortAssemblyQualifiedName();
+                var typeNameBytes = Encoding.UTF8.GetBytes(typeName);
+                return new[] { ObjectSerializer.ManifestFull }
+                    .Concat(BitConverter.GetBytes(typeNameBytes.Length))
+                    .Concat(typeNameBytes)
+                    .ToArray(); //serializer id 255 + assembly qualified name
+            });
+        }
+
+        private static Type GetTypeFromManifestName(Stream stream, DeserializerSession session)
+        {
+            var bytes = (byte[])ByteArraySerializer.Instance.ReadValue(stream, session);
+
+            return Name2TypeMap.GetOrAdd(bytes, b =>
+            {
+                var shortName = Encoding.UTF8.GetString(b);
+                var typename = Utils.ToQualifiedAssemblyName(shortName);
+                return Type.GetType(typename, true);
+            });
+        }
+
+        public void WriteType(Stream stream, Type type, SerializerSession session)
+        {
+            if (session.ShouldWriteTypeManifest(type))
+            {
+                stream.Write(GetManifestNameFromType(type));
+            }
+            else
+            {
+                var typeIdentifier = session.GetTypeIdentifier(type);
+                stream.Write(new[] { ObjectSerializer.ManifestIndex });
+                stream.WriteUInt16((ushort)typeIdentifier);
+            }
+        }
+
+        public Type ReadType(Stream stream, int firstManifest, DeserializerSession session)
+        {
+            if (firstManifest == ObjectSerializer.ManifestFull)
+            {
+                var type = GetTypeFromManifestName(stream, session);
+                session.TrackDeserializedType(type);
+                return type;
+            }
+            else
+            {
+                var typeId = stream.ReadUInt16(session);
+                var type = session.GetTypeFromTypeId(typeId);
+                return type;
+            }
+        }
+    }
+}

--- a/Wire/ITypeResolver.cs
+++ b/Wire/ITypeResolver.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.IO;
+
+namespace Wire
+{
+    public interface ITypeResolver
+    {
+        void WriteType(Stream stream, Type type, SerializerSession session);
+        Type ReadType(Stream stream, int firstManifest, DeserializerSession session);
+    }
+}

--- a/Wire/Serializer.cs
+++ b/Wire/Serializer.cs
@@ -346,13 +346,9 @@ namespace Wire
                 case ConsistentArraySerializer.Manifest:
                     return ConsistentArraySerializer.Instance;
                 case ObjectSerializer.ManifestFull:
-                {
-                    var type = ObjectSerializer.GetTypeFromManifestFull(stream, session);
-                    return GetCustomDeserialzer(type);
-                }
                 case ObjectSerializer.ManifestIndex:
                 {
-                    var type = ObjectSerializer.GetTypeFromManifestIndex(stream, session);
+                    var type = session.Serializer.Options.TypeResolver.ReadType(stream, first, session);
                     return GetCustomDeserialzer(type);
                 }
                 default:

--- a/Wire/SerializerOptions.cs
+++ b/Wire/SerializerOptions.cs
@@ -28,9 +28,12 @@ namespace Wire
         internal readonly Surrogate[] Surrogates;
         internal readonly ValueSerializerFactory[] ValueSerializerFactories;
         internal readonly bool VersionTolerance;
+        internal readonly ITypeResolver TypeResolver;
 
-        public SerializerOptions(bool versionTolerance = false, IEnumerable<Surrogate> surrogates = null,
-            bool preserveObjectReferences = false, IEnumerable<ValueSerializerFactory> serializerFactories = null)
+        public SerializerOptions(
+            bool versionTolerance = false, IEnumerable<Surrogate> surrogates = null,
+            bool preserveObjectReferences = false, IEnumerable<ValueSerializerFactory> serializerFactories = null,
+            ITypeResolver typeResolver = null)
         {
             VersionTolerance = versionTolerance;
             Surrogates = surrogates?.ToArray() ?? EmptySurrogates;
@@ -41,6 +44,7 @@ namespace Wire
                     .ToArray();
 
             PreserveObjectReferences = preserveObjectReferences;
+            TypeResolver = typeResolver ?? new DefaultTypeResolver();
         }
     }
 }

--- a/Wire/Wire.csproj
+++ b/Wire/Wire.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="ByteArrayEqualityComparer.cs" />
     <Compile Include="CodeGenerator.cs" />
+    <Compile Include="DefaultTypeResolver.cs" />
     <Compile Include="SerializerFactories\ArraySerializerFactory.cs" />
     <Compile Include="SerializerFactories\DefaultDictionarySerializerFactory.cs" />
     <Compile Include="SerializerFactories\DictionarySerializerFactory.cs" />
@@ -59,6 +60,7 @@
     <Compile Include="SerializerOptions.cs" />
     <Compile Include="StreamExtensions.cs" />
     <Compile Include="Surrogate.cs" />
+    <Compile Include="ITypeResolver.cs" />
     <Compile Include="Utils.cs" />
     <Compile Include="ValueSerializers\BoolSerializer.cs" />
     <Compile Include="ValueSerializers\ByteArraySerializer.cs" />


### PR DESCRIPTION
### Motivation

I want to shorten `TypeName` used in `ObjectSerializer`. `TypeName` looks like:

> Wire.Tests.Something, Wire.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null

It's good enough to be a default but quite lengthy for the situation that limited types are used.

For example, if there is no ambiguity for resolving types without assembly name, the assembly part of `typename` could be stripped out like:

> Wire.Tests.Something

Or even with the predefined type to ID table like [TypeAlias](https://github.com/SaladLab/TypeAlias), `TypeName` could be just simple integer.

> 10

If we can customize how wire write type to byte[] and read type from byte[], previous cases will be able to be implemented.
### How ?

Add new `ITypeResolver` which deals with type resolving jobs. It has two simple methods.

``` csharp
public interface ITypeResolver
{
    void WriteType(Stream stream, Type type, SerializerSession session);
    Type ReadType(Stream stream, int firstManifest, DeserializerSession session);
}
```

Add `ITypeResolver` to `SerializerOptions`, which can customize each serializer how to resolve types.
By default, it uses `DefaultTypeResolver` which works exactly same as it used to be.

``` csharp
public class SerializerOptions
{
    ...
    internal readonly ITypeResolver TypeResolver;

    public SerializerOptions(..., ITypeResolver typeResolver = null)
    {
        ...
        TypeResolver = typeResolver ?? new DefaultTypeResolver();
    }
}
```
