### PR TITLE
Support AOT environment. (#38)

### DIFF
--- a/Wire.PerformanceTests/SpeedAndSizeTests.cs
+++ b/Wire.PerformanceTests/SpeedAndSizeTests.cs
@@ -261,7 +261,7 @@ namespace Wire.PerformanceTests
 
         private void Test(object value)
         {
-            Serializer wireSerializer = new Serializer(new SerializerOptions(false,true,null, null));
+            Serializer wireSerializer = new Serializer(new SerializerOptions(preserveObjectReferences: true));
             var pickler = FsPickler.CreateBinarySerializer();
 
             double wireTs;

--- a/Wire.Tests/CollectionTests.cs
+++ b/Wire.Tests/CollectionTests.cs
@@ -221,6 +221,16 @@ namespace Wire.Tests
             Reset();
             var actual = Deserialize<DateTime[]>();
             CollectionAssert.AreEqual(expected, actual);
-        }        
+        }
+
+        [TestMethod]
+        public void CanSerializePrimitiveArray2()
+        {
+            var expected = new[] { 1, 2, 3, 4 };
+            Serialize(expected);
+            Reset();
+            var actual = Deserialize<int[]>();
+            CollectionAssert.AreEqual(expected, actual);
+        }
     }
 }

--- a/Wire/DefaultCodeGenerator.cs
+++ b/Wire/DefaultCodeGenerator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Wire.ValueSerializers;

--- a/Wire/SerializerOptions.cs
+++ b/Wire/SerializerOptions.cs
@@ -27,18 +27,27 @@ namespace Wire
             new ISerializableSerializerFactory(), //TODO: this will mess up the indexes in the serializer payload
 #endif
             new EnumerableSerializerFactory(),
-            
         };
 
+        internal readonly bool VersionTolerance;
         internal readonly bool PreserveObjectReferences;
+        internal readonly bool UseDynamicCode;
         internal readonly Surrogate[] Surrogates;
         internal readonly ValueSerializerFactory[] ValueSerializerFactories;
-        internal readonly bool VersionTolerance;
         internal readonly Type[] KnownTypes;
 
-        public SerializerOptions(bool versionTolerance = false, bool preserveObjectReferences = false, IEnumerable<Surrogate> surrogates = null, IEnumerable<ValueSerializerFactory> serializerFactories = null, IEnumerable<Type> knownTypes = null)
+        public SerializerOptions(
+            bool versionTolerance = false,
+            bool preserveObjectReferences = false,
+            bool? useDynamicCode = null,
+            IEnumerable<Surrogate> surrogates = null,
+            IEnumerable<ValueSerializerFactory> serializerFactories = null,
+            IEnumerable<Type> knownTypes = null)
         {
             VersionTolerance = versionTolerance;
+            PreserveObjectReferences = preserveObjectReferences;
+            UseDynamicCode = useDynamicCode ?? GetDefaultUseDynamicCode();
+
             Surrogates = surrogates?.ToArray() ?? EmptySurrogates;
 
             //use the default factories + any user defined
@@ -47,8 +56,12 @@ namespace Wire
                     .ToArray();
 
             KnownTypes = knownTypes?.ToArray() ?? new Type[] {};
+        }
 
-            PreserveObjectReferences = preserveObjectReferences;
+        private static bool GetDefaultUseDynamicCode()
+        {
+            // TODO: check if system supports dynamic code or not. (it should be false on iOS.)
+            return true;
         }
     }
 }

--- a/Wire/ValueSerializers/ConsistentArraySerializer.cs
+++ b/Wire/ValueSerializers/ConsistentArraySerializer.cs
@@ -8,6 +8,61 @@ namespace Wire.ValueSerializers
         public const byte Manifest = 252;
         public static readonly ConsistentArraySerializer Instance = new ConsistentArraySerializer();
 
+        public override void WriteManifest(Stream stream, SerializerSession session)
+        {
+            stream.WriteByte(Manifest);
+        }
+
+        public override void WriteValue(Stream stream, object value, SerializerSession session)
+        {
+            if (session.Serializer.Options.PreserveObjectReferences)
+            {
+                session.TrackSerializedObject(value);
+            }
+
+            var array = (Array)value;
+            var elementType = array.GetType().GetElementType();
+            var elementSerializer = session.Serializer.GetSerializerByType(elementType);
+            elementSerializer.WriteManifest(stream, session); //write array element type
+
+            if (elementType.IsFixedSizeType())
+                WriteValuesFixedSize(array, elementType, stream, elementSerializer, session);
+            else if (session.Serializer.Options.UseDynamicCode)
+                WriteValues((dynamic)array, stream, elementSerializer, session);
+            else
+                WriteValuesNonGeneric(array, stream, elementSerializer, session);
+        }
+
+        private static void WriteValuesFixedSize(Array array, Type elementType, Stream stream, ValueSerializer elementSerializer, SerializerSession session)
+        {
+            var length = array.Length;
+            stream.WriteInt32(length);
+            var size = elementType.GetTypeSize();
+            byte[] result = new byte[length * size];
+            Buffer.BlockCopy(array, 0, result, 0, result.Length);
+            stream.Write(result);
+        }
+
+        private static void WriteValues<T>(T[] array, Stream stream, ValueSerializer elementSerializer, SerializerSession session)
+        {
+            stream.WriteInt32(array.Length);
+            foreach (var value in array)
+            {
+                elementSerializer.WriteValue(stream, value, session);
+            }
+        }
+
+        private static void WriteValuesNonGeneric(Array array, Stream stream, ValueSerializer elementSerializer, SerializerSession session)
+        {
+            var length = array.Length;
+            stream.WriteInt32(length);
+            for (int i = 0; i < length; i++)
+            {
+                var value = array.GetValue(i);
+                elementSerializer.WriteValue(stream, value, session);
+            }
+        }
+
         public override object ReadValue(Stream stream, DeserializerSession session)
         {
             var elementSerializer = session.Serializer.GetDeserializerByManifest(stream, session);
@@ -21,57 +76,45 @@ namespace Wire.ValueSerializers
                 session.TrackDeserializedObject(array);
             }
 
-            for (var i = 0; i < length; i++)
-            {
-                var value = elementSerializer.ReadValue(stream, session); //read the element value
-                array.SetValue(value, i); //set the element value
-            }
-
+            if (elementType.IsFixedSizeType())
+                ReadValuesFixedSize(stream, array, elementType, elementSerializer, session);
+            else if (session.Serializer.Options.UseDynamicCode)
+                ReadValues(stream, (dynamic)array, elementSerializer, session);
+            else
+                ReadValuesNonGeneric(stream, array, elementSerializer, session);
 
             return array;
+        }
+
+        private static void ReadValuesFixedSize(Stream stream, Array array, Type elementType, ValueSerializer elementSerializer, DeserializerSession session)
+        {
+            var size = elementType.GetTypeSize();
+            var temp = new byte[array.Length * size];
+            stream.Read(temp, 0, temp.Length);
+            Buffer.BlockCopy(temp, 0, array, 0, temp.Length);
+        }
+
+        private static void ReadValues<T>(Stream stream, T[] array, ValueSerializer elementSerializer, DeserializerSession session)
+        {
+            for (var i = 0; i < array.Length; i++)
+            {
+                var value = elementSerializer.ReadValue(stream, session);
+                array[i] = (T)value;
+            }
+        }
+
+        private static void ReadValuesNonGeneric(Stream stream, Array array, ValueSerializer elementSerializer, DeserializerSession session)
+        {
+            for (var i = 0; i < array.Length; i++)
+            {
+                var value = elementSerializer.ReadValue(stream, session);
+                array.SetValue(value, i);
+            }
         }
 
         public override Type GetElementType()
         {
             throw new NotSupportedException();
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
-        }
-
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            if (session.Serializer.Options.PreserveObjectReferences)
-            {
-                session.TrackSerializedObject(value);
-            }
-            var elementType = value.GetType().GetElementType();
-            var elementSerializer = session.Serializer.GetSerializerByType(elementType);
-            elementSerializer.WriteManifest(stream, session); //write array element type
-            // ReSharper disable once PossibleNullReferenceException
-            WriteValues((dynamic)value, stream,elementSerializer,session);
-
-        }
-
-        private static void WriteValues<T>(T[] array, Stream stream, ValueSerializer elementSerializer, SerializerSession session)
-        {
-            stream.WriteInt32(array.Length);
-            if (typeof(T).IsFixedSizeType())
-            {
-                var size = typeof(T).GetTypeSize();
-                var result = new byte[array.Length * size];
-                Buffer.BlockCopy(array, 0, result, 0, result.Length);
-                stream.Write(result);
-            }
-            else
-            {
-                foreach (var value in array)
-                {
-                    elementSerializer.WriteValue(stream, value, session);
-                }
-            }    
         }
     }
 }


### PR DESCRIPTION
### What's done:
#### `SerializerOptions`
-  Add `UseDynamicCode` option which determines whether runtime generic and dynamic code will be used. (default: `true`)
#### `ArraySerializerFactory`
- Add non generic read and write methods for supporting AOT.
- Make generated read and write code fully utilize given type info for better performance.
#### `ConsistentArraySerializer`
- Add non generic read and write methods for supporting AOT.
- Make `ReadValue` use `ReadValues<T>` and `ReadValuesFixedSize` for better performance.
#### `DefaultCodeGenerator`
- Add non generic read and write methods for supporting AOT.
