### PR TITLE
Add missing GetBuffer to GuidSerializer.

### DIFF
--- a/Wire/ValueSerializers/GuidSerializer.cs
+++ b/Wire/ValueSerializers/GuidSerializer.cs
@@ -21,7 +21,7 @@ namespace Wire.ValueSerializers
 
         public override object ReadValue(Stream stream, DeserializerSession session)
         {
-            var buffer = new byte[16];
+            var buffer = session.GetBuffer(16);
             stream.Read(buffer, 0, 16);
             return new Guid(buffer);
         }


### PR DESCRIPTION
`GuidSerializer` is updated to use `session.GetBuffer` like other primitive serializers to reduce GC workload.
