### PR TITLE
byte & sbyte serializers fixed

### DIFF
--- a/Wire.Tests/PrimitivesTests.cs
+++ b/Wire.Tests/PrimitivesTests.cs
@@ -144,6 +144,7 @@ namespace Wire.Tests
             Reset();
             var res = Deserialize<object>();
             Assert.AreEqual(expected, res);
+            AssertMemoryStreamConsumed();
         }
     }
 }

--- a/Wire.Tests/TestBase.cs
+++ b/Wire.Tests/TestBase.cs
@@ -30,5 +30,10 @@ namespace Wire.Tests
         {
             return serializer.Deserialize<T>(stream);
         }
+
+        public void AssertMemoryStreamConsumed()
+        {
+            Assert.AreEqual(stream.Length, stream.Position);
+        }
     }
 }

--- a/Wire/ValueSerializers/ByteSerializer.cs
+++ b/Wire/ValueSerializers/ByteSerializer.cs
@@ -15,8 +15,7 @@ namespace Wire.ValueSerializers
 
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
-            var bytes = BitConverter.GetBytes((byte) value);
-            stream.Write(bytes);
+            stream.WriteByte((byte) value);
         }
 
         public override object ReadValue(Stream stream, DeserializerSession session)
@@ -26,7 +25,7 @@ namespace Wire.ValueSerializers
 
         public override Type GetElementType()
         {
-            return typeof (byte);
+            return typeof(byte);
         }
     }
 }

--- a/Wire/ValueSerializers/SByteSerializer.cs
+++ b/Wire/ValueSerializers/SByteSerializer.cs
@@ -13,20 +13,21 @@ namespace Wire.ValueSerializers
             stream.WriteByte(Manifest);
         }
 
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
+        public override unsafe void WriteValue(Stream stream, object value, SerializerSession session)
         {
-            var bytes = BitConverter.GetBytes((sbyte) value);
-            stream.Write(bytes);
+            var @sbyte = (sbyte) value;
+            stream.WriteByte(*(byte*) &@sbyte);
         }
 
-        public override object ReadValue(Stream stream, DeserializerSession session)
+        public override unsafe object ReadValue(Stream stream, DeserializerSession session)
         {
-            return (sbyte) stream.ReadByte();
+            var @byte = (byte) stream.ReadByte();
+            return *(sbyte*) &@byte;
         }
 
         public override Type GetElementType()
         {
-            return typeof (sbyte);
+            return typeof(sbyte);
         }
     }
 }


### PR DESCRIPTION
Previously these two serializers were writing 2 bytes reading only 1.

`TestBase` now provides assertion method ensuring that the stream was read till the end (this showed the broken implementation for byte and sbyte).
