### PR TITLE
Better value serializers

### DIFF
--- a/Wire.Tests/PrimitivesTests.cs
+++ b/Wire.Tests/PrimitivesTests.cs
@@ -15,7 +15,7 @@ namespace Wire.Tests
         [TestMethod]
         public void CanSerializeTuple2()
         {
-            SerializeAndAssert(Tuple.Create(1,123));
+            SerializeAndAssert(Tuple.Create(1, 123));
         }
 
         [TestMethod]

--- a/Wire/DefaultCodeGenerator.cs
+++ b/Wire/DefaultCodeGenerator.cs
@@ -26,15 +26,16 @@ namespace Wire
             var session = c.Parameter<DeserializerSession>("session");
             var newExpression = c.NewObject(type);
             var target = c.Variable<object>("target");
-            var assignNewObjectToTarget = c.WriteVar(target,newExpression);
+            var assignNewObjectToTarget = c.WriteVar(target, newExpression);
 
             c.Emit(assignNewObjectToTarget);
 
             if (serializer.Options.PreserveObjectReferences)
             {
-                var trackDeserializedObjectMethod = typeof(DeserializerSession).GetMethod(nameof(DeserializerSession.TrackDeserializedObject));
+                var trackDeserializedObjectMethod =
+                    typeof(DeserializerSession).GetMethod(nameof(DeserializerSession.TrackDeserializedObject));
 
-                c.EmitCall(trackDeserializedObjectMethod,session,target);
+                c.EmitCall(trackDeserializedObjectMethod, session, target);
             }
 
             //for (var i = 0; i < storedFieldCount; i++)
@@ -69,20 +70,19 @@ namespace Wire
                     //which we cannot do w/o a manifest
                     var method = typeof(ValueSerializer).GetMethod(nameof(ValueSerializer.ReadValue));
                     var ss = c.Constant(s);
-                    read = c.Call(method,ss,stream,session);
+                    read = c.Call(method, ss, stream, session);
                 }
                 else
                 {
                     var method = typeof(StreamExtensions).GetMethod(nameof(StreamExtensions.ReadObject));
-                    read = c.StaticCall(method,stream,session);
+                    read = c.StaticCall(method, stream, session);
                 }
 
-                var typedTarget = c.CastOrUnbox(target,type);
+                var typedTarget = c.CastOrUnbox(target, type);
 
                 var typedRead = c.Convert(read, field.FieldType);
                 var assign = c.WriteField(field, typedTarget, typedRead);
                 c.Emit(assign);
-
             }
             c.Emit(target);
 
@@ -95,7 +95,7 @@ namespace Wire
         private ObjectWriter GetFieldsWriter(Serializer serializer, IEnumerable<FieldInfo> fields)
         {
             var c = new Compiler<ObjectWriter>();
-            
+
             var stream = c.Parameter<Stream>("stream");
             var target = c.Parameter<object>("target");
             var session = c.Parameter<SerializerSession>("session");
@@ -105,7 +105,7 @@ namespace Wire
             {
                 var method = typeof(SerializerSession).GetMethod(nameof(SerializerSession.TrackSerializedObject));
 
-                c.EmitCall(method,session,target);
+                c.EmitCall(method, session, target);
             }
 
             foreach (var field in fields)
@@ -113,23 +113,19 @@ namespace Wire
                 //get the serializer for the type of the field
                 var valueSerializer = serializer.GetSerializerByType(field.FieldType);
                 //runtime Get a delegate that reads the content of the given field
-                
+
                 var cast = c.CastOrUnbox(target, field.DeclaringType);
-                var readField = c.ReadField(field,cast);
-                var converted = c.ConvertTo<object>(readField);
+                var readField = c.ReadField(field, cast);
 
                 //if the type is one of our special primitives, ignore manifest as the content will always only be of this type
                 if (!serializer.Options.VersionTolerance && field.FieldType.IsWirePrimitive())
                 {
                     //primitive types does not need to write any manifest, if the field type is known
-                    //nor can they be null (StringSerializer has it's own null handling)
-                    var method = typeof(ValueSerializer).GetMethod(nameof(ValueSerializer.WriteValue));
-                    //write it to the value serializer
-                    var vs = c.Constant( valueSerializer);
-                    c.EmitCall(method, vs, stream, converted, session);
+                    valueSerializer.EmitWriteValue(c, stream, readField, session);
                 }
                 else
                 {
+                    var converted = c.ConvertTo<object>(readField);
                     var valueType = field.FieldType;
                     if (field.FieldType.IsNullable())
                     {
@@ -143,11 +139,12 @@ namespace Wire
 
                     var method = typeof(StreamExtensions).GetMethod(nameof(StreamExtensions.WriteObject));
 
-                    c.EmitStaticCall(method,stream, converted,vt,vs,preserveReferences,session);
+                    c.EmitStaticCall(method, stream, converted, vt, vs, preserveReferences, session);
                 }
             }
 
-            return c.Compile(); ;
+            return c.Compile();
+            ;
         }
     }
 }

--- a/Wire/ValueSerializers/BoolSerializer.cs
+++ b/Wire/ValueSerializers/BoolSerializer.cs
@@ -1,23 +1,20 @@
-using System;
 using System.IO;
-using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
-    public class BoolSerializer : ValueSerializer
+    public class BoolSerializer : SessionIgnorantValueSerializer<bool>
     {
         public const byte Manifest = 6;
         public static readonly BoolSerializer Instance = new BoolSerializer();
 
+        public BoolSerializer() : 
+            base(() => WriteValueImpl)
+        {
+        }
+
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
-        }
-
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var b = (bool) value;
-            WriteValueImpl(stream, b);
         }
 
         public override object ReadValue(Stream stream, DeserializerSession session)
@@ -25,21 +22,10 @@ namespace Wire.ValueSerializers
             var b = stream.ReadByte();
             return b != 0;
         }
-
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, fieldValue);
-        }
-
+        
         public static void WriteValueImpl(Stream stream, bool b)
         {
             stream.WriteByte((byte) (b ? 1 : 0));
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(bool);
         }
     }
 }

--- a/Wire/ValueSerializers/BoolSerializer.cs
+++ b/Wire/ValueSerializers/BoolSerializer.cs
@@ -8,13 +8,8 @@ namespace Wire.ValueSerializers
         public static readonly BoolSerializer Instance = new BoolSerializer();
 
         public BoolSerializer() : 
-            base(() => WriteValueImpl)
+            base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         public override object ReadValue(Stream stream, DeserializerSession session)

--- a/Wire/ValueSerializers/BoolSerializer.cs
+++ b/Wire/ValueSerializers/BoolSerializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
@@ -16,7 +17,7 @@ namespace Wire.ValueSerializers
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
             var b = (bool) value;
-            stream.WriteByte((byte) (b ? 1 : 0));
+            WriteValueImpl(stream, b);
         }
 
         public override object ReadValue(Stream stream, DeserializerSession session)
@@ -25,9 +26,20 @@ namespace Wire.ValueSerializers
             return b != 0;
         }
 
+        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var method = GetType().GetMethod(nameof(WriteValueImpl));
+            c.EmitStaticCall(method, stream, fieldValue);
+        }
+
+        public static void WriteValueImpl(Stream stream, bool b)
+        {
+            stream.WriteByte((byte) (b ? 1 : 0));
+        }
+
         public override Type GetElementType()
         {
-            return typeof (bool);
+            return typeof(bool);
         }
     }
 }

--- a/Wire/ValueSerializers/ByteSerializer.cs
+++ b/Wire/ValueSerializers/ByteSerializer.cs
@@ -7,13 +7,8 @@ namespace Wire.ValueSerializers
         public const byte Manifest = 4;
         public static readonly ByteSerializer Instance = new ByteSerializer();
 
-        public ByteSerializer() : base(() => WriteValueImpl)
+        public ByteSerializer() : base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         public static void WriteValueImpl(Stream stream, byte b)

--- a/Wire/ValueSerializers/ByteSerializer.cs
+++ b/Wire/ValueSerializers/ByteSerializer.cs
@@ -1,29 +1,19 @@
-﻿using System;
-using System.IO;
-using Wire.ExpressionDSL;
+﻿using System.IO;
 
 namespace Wire.ValueSerializers
 {
-    public class ByteSerializer : ValueSerializer
+    public class ByteSerializer : SessionIgnorantValueSerializer<byte>
     {
         public const byte Manifest = 4;
         public static readonly ByteSerializer Instance = new ByteSerializer();
 
+        public ByteSerializer() : base(() => WriteValueImpl)
+        {
+        }
+
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
-        }
-
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var b = (byte) value;
-            WriteValueImpl(stream, b);
-        }
-
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, fieldValue);
         }
 
         public static void WriteValueImpl(Stream stream, byte b)
@@ -34,11 +24,6 @@ namespace Wire.ValueSerializers
         public override object ReadValue(Stream stream, DeserializerSession session)
         {
             return (byte) stream.ReadByte();
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(byte);
         }
     }
 }

--- a/Wire/ValueSerializers/ByteSerializer.cs
+++ b/Wire/ValueSerializers/ByteSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
@@ -15,7 +16,19 @@ namespace Wire.ValueSerializers
 
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
-            stream.WriteByte((byte) value);
+            var b = (byte) value;
+            WriteValueImpl(stream, b);
+        }
+
+        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var method = GetType().GetMethod(nameof(WriteValueImpl));
+            c.EmitStaticCall(method, stream, fieldValue);
+        }
+
+        public static void WriteValueImpl(Stream stream, byte b)
+        {
+            stream.WriteByte(b);
         }
 
         public override object ReadValue(Stream stream, DeserializerSession session)

--- a/Wire/ValueSerializers/CharSerializer.cs
+++ b/Wire/ValueSerializers/CharSerializer.cs
@@ -1,24 +1,21 @@
 ﻿using System;
 using System.IO;
-using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
-    public class CharSerializer : ValueSerializer
+    public class CharSerializer : SessionAwareValueSerializer<char>
     {
         public const byte Manifest = 15;
         public const int Size = sizeof(char);
         public static readonly CharSerializer Instance = new CharSerializer();
 
+        public CharSerializer() : base(() => WriteValueImpl)
+        {
+        }
+
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
-        }
-
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var ch = (char) value;
-            WriteValueImpl(stream, session, ch);
         }
 
         public override object ReadValue(Stream stream, DeserializerSession session)
@@ -28,21 +25,10 @@ namespace Wire.ValueSerializers
             return BitConverter.ToSingle(buffer, 0);
         }
 
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, session, fieldValue);
-        }
-
-        public static void WriteValueImpl(Stream stream, SerializerSession session, char ch)
+        public static void WriteValueImpl(Stream stream, char ch, SerializerSession session)
         {
             var bytes = NoAllocBitConverter.GetBytes(ch, session);
             stream.Write(bytes, 0, Size);
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(char);
         }
     }
 }

--- a/Wire/ValueSerializers/CharSerializer.cs
+++ b/Wire/ValueSerializers/CharSerializer.cs
@@ -9,13 +9,8 @@ namespace Wire.ValueSerializers
         public const int Size = sizeof(char);
         public static readonly CharSerializer Instance = new CharSerializer();
 
-        public CharSerializer() : base(() => WriteValueImpl)
+        public CharSerializer() : base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         public override object ReadValue(Stream stream, DeserializerSession session)

--- a/Wire/ValueSerializers/DateTimeSerializer.cs
+++ b/Wire/ValueSerializers/DateTimeSerializer.cs
@@ -1,6 +1,6 @@
 using System;
-using System.ComponentModel;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
@@ -18,6 +18,17 @@ namespace Wire.ValueSerializers
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
             var dateTime = (DateTime) value;
+            WriteValueImpl(stream, session, dateTime);
+        }
+
+        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var method = GetType().GetMethod(nameof(WriteValueImpl));
+            c.EmitStaticCall(method, stream, session, fieldValue);
+        }
+
+        static void WriteValueImpl(Stream stream, SerializerSession session, DateTime dateTime)
+        {
             var bytes = NoAllocBitConverter.GetBytes(dateTime.Ticks, session);
             stream.Write(bytes, 0, Size);
             var kindByte = (byte) dateTime.Kind;

--- a/Wire/ValueSerializers/DateTimeSerializer.cs
+++ b/Wire/ValueSerializers/DateTimeSerializer.cs
@@ -9,13 +9,8 @@ namespace Wire.ValueSerializers
         public const int Size = sizeof(long);
         public static readonly DateTimeSerializer Instance = new DateTimeSerializer();
 
-        public DateTimeSerializer() : base(() => WriteValueImpl)
+        public DateTimeSerializer() : base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         static void WriteValueImpl(Stream stream, DateTime dateTime, SerializerSession session)

--- a/Wire/ValueSerializers/DateTimeSerializer.cs
+++ b/Wire/ValueSerializers/DateTimeSerializer.cs
@@ -1,33 +1,24 @@
 using System;
 using System.IO;
-using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
-    public class DateTimeSerializer : ValueSerializer
+    public class DateTimeSerializer : SessionAwareValueSerializer<DateTime>
     {
         public const byte Manifest = 5;
         public const int Size = sizeof(long);
         public static readonly DateTimeSerializer Instance = new DateTimeSerializer();
+
+        public DateTimeSerializer() : base(() => WriteValueImpl)
+        {
+        }
 
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
         }
 
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var dateTime = (DateTime) value;
-            WriteValueImpl(stream, session, dateTime);
-        }
-
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, session, fieldValue);
-        }
-
-        static void WriteValueImpl(Stream stream, SerializerSession session, DateTime dateTime)
+        static void WriteValueImpl(Stream stream, DateTime dateTime, SerializerSession session)
         {
             var bytes = NoAllocBitConverter.GetBytes(dateTime.Ticks, session);
             stream.Write(bytes, 0, Size);
@@ -43,11 +34,6 @@ namespace Wire.ValueSerializers
             var kind = (DateTimeKind) stream.ReadByte();
             var dateTime = new DateTime(ticks, kind);
             return dateTime;
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(DateTime);
         }
     }
 }

--- a/Wire/ValueSerializers/DoubleSerializer.cs
+++ b/Wire/ValueSerializers/DoubleSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
@@ -16,7 +17,19 @@ namespace Wire.ValueSerializers
 
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
-            var bytes = NoAllocBitConverter.GetBytes((double) value, session);
+            var d = (double) value;
+            WriteValueImpl(stream, session, d);
+        }
+
+        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var method = GetType().GetMethod(nameof(WriteValueImpl));
+            c.EmitStaticCall(method, stream, session, fieldValue);
+        }
+
+        public static void WriteValueImpl(Stream stream, SerializerSession session, double d)
+        {
+            var bytes = NoAllocBitConverter.GetBytes(d, session);
             stream.Write(bytes, 0, Size);
         }
 

--- a/Wire/ValueSerializers/DoubleSerializer.cs
+++ b/Wire/ValueSerializers/DoubleSerializer.cs
@@ -1,33 +1,24 @@
 ﻿using System;
 using System.IO;
-using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
-    public class DoubleSerializer : ValueSerializer
+    public class DoubleSerializer : SessionAwareValueSerializer<double>
     {
         public const byte Manifest = 13;
         const int Size = sizeof(double);
         public static readonly DoubleSerializer Instance = new DoubleSerializer();
+
+        public DoubleSerializer() : base(() => WriteValueImpl)
+        {
+        }
 
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
         }
 
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var d = (double) value;
-            WriteValueImpl(stream, session, d);
-        }
-
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, session, fieldValue);
-        }
-
-        public static void WriteValueImpl(Stream stream, SerializerSession session, double d)
+        public static void WriteValueImpl(Stream stream, double d, SerializerSession session)
         {
             var bytes = NoAllocBitConverter.GetBytes(d, session);
             stream.Write(bytes, 0, Size);
@@ -38,11 +29,6 @@ namespace Wire.ValueSerializers
             var buffer = session.GetBuffer(Size);
             stream.Read(buffer, 0, Size);
             return BitConverter.ToDouble(buffer, 0);
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(double);
         }
     }
 }

--- a/Wire/ValueSerializers/DoubleSerializer.cs
+++ b/Wire/ValueSerializers/DoubleSerializer.cs
@@ -9,13 +9,8 @@ namespace Wire.ValueSerializers
         const int Size = sizeof(double);
         public static readonly DoubleSerializer Instance = new DoubleSerializer();
 
-        public DoubleSerializer() : base(() => WriteValueImpl)
+        public DoubleSerializer() : base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         public static void WriteValueImpl(Stream stream, double d, SerializerSession session)

--- a/Wire/ValueSerializers/FloatSerializer.cs
+++ b/Wire/ValueSerializers/FloatSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
@@ -16,7 +17,19 @@ namespace Wire.ValueSerializers
 
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
-            var bytes = NoAllocBitConverter.GetBytes((float) value, session);
+            var f = (float) value;
+            WriteValueImpl(stream, session, f);
+        }
+
+        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var method = GetType().GetMethod(nameof(WriteValueImpl));
+            c.EmitStaticCall(method, stream, session, fieldValue);
+        }
+
+        public static void WriteValueImpl(Stream stream, SerializerSession session, float f)
+        {
+            var bytes = NoAllocBitConverter.GetBytes(f, session);
             stream.Write(bytes, 0, Size);
         }
 

--- a/Wire/ValueSerializers/FloatSerializer.cs
+++ b/Wire/ValueSerializers/FloatSerializer.cs
@@ -9,13 +9,8 @@ namespace Wire.ValueSerializers
         public const int Size = sizeof(float);
         public static readonly FloatSerializer Instance = new FloatSerializer();
 
-        public FloatSerializer() : base(() => WriteValueImpl)
+        public FloatSerializer() : base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         public static void WriteValueImpl(Stream stream, float f, SerializerSession session)

--- a/Wire/ValueSerializers/FloatSerializer.cs
+++ b/Wire/ValueSerializers/FloatSerializer.cs
@@ -1,33 +1,24 @@
 ﻿using System;
 using System.IO;
-using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
-    public class FloatSerializer : ValueSerializer
+    public class FloatSerializer : SessionAwareValueSerializer<float>
     {
         public const byte Manifest = 12;
         public const int Size = sizeof(float);
         public static readonly FloatSerializer Instance = new FloatSerializer();
+
+        public FloatSerializer() : base(() => WriteValueImpl)
+        {
+        }
 
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
         }
 
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var f = (float) value;
-            WriteValueImpl(stream, session, f);
-        }
-
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, session, fieldValue);
-        }
-
-        public static void WriteValueImpl(Stream stream, SerializerSession session, float f)
+        public static void WriteValueImpl(Stream stream, float f, SerializerSession session)
         {
             var bytes = NoAllocBitConverter.GetBytes(f, session);
             stream.Write(bytes, 0, Size);
@@ -38,11 +29,6 @@ namespace Wire.ValueSerializers
             var buffer = session.GetBuffer(Size);
             stream.Read(buffer, 0, Size);
             return BitConverter.ToSingle(buffer, 0);
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(float);
         }
     }
 }

--- a/Wire/ValueSerializers/GuidSerializer.cs
+++ b/Wire/ValueSerializers/GuidSerializer.cs
@@ -8,13 +8,8 @@ namespace Wire.ValueSerializers
         public const byte Manifest = 11;
         public static readonly GuidSerializer Instance = new GuidSerializer();
 
-        public GuidSerializer() : base(() => WriteValueImpl)
+        public GuidSerializer() : base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         public static void WriteValueImpl(Stream stream, Guid g)

--- a/Wire/ValueSerializers/GuidSerializer.cs
+++ b/Wire/ValueSerializers/GuidSerializer.cs
@@ -1,29 +1,20 @@
 ﻿using System;
 using System.IO;
-using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
-    public class GuidSerializer : ValueSerializer
+    public class GuidSerializer : SessionIgnorantValueSerializer<Guid>
     {
         public const byte Manifest = 11;
         public static readonly GuidSerializer Instance = new GuidSerializer();
 
+        public GuidSerializer() : base(() => WriteValueImpl)
+        {
+        }
+
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
-        }
-
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var g = (Guid) value;
-            WriteValueImpl(stream, g);
-        }
-
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, fieldValue);
         }
 
         public static void WriteValueImpl(Stream stream, Guid g)
@@ -37,11 +28,6 @@ namespace Wire.ValueSerializers
             var buffer = new byte[16];
             stream.Read(buffer, 0, 16);
             return new Guid(buffer);
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(Guid);
         }
     }
 }

--- a/Wire/ValueSerializers/GuidSerializer.cs
+++ b/Wire/ValueSerializers/GuidSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
@@ -15,7 +16,19 @@ namespace Wire.ValueSerializers
 
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
-            var bytes = ((Guid) value).ToByteArray();
+            var g = (Guid) value;
+            WriteValueImpl(stream, g);
+        }
+
+        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var method = GetType().GetMethod(nameof(WriteValueImpl));
+            c.EmitStaticCall(method, stream, fieldValue);
+        }
+
+        public static void WriteValueImpl(Stream stream, Guid g)
+        {
+            var bytes = g.ToByteArray();
             stream.Write(bytes);
         }
 
@@ -28,7 +41,7 @@ namespace Wire.ValueSerializers
 
         public override Type GetElementType()
         {
-            return typeof (Guid);
+            return typeof(Guid);
         }
     }
 }

--- a/Wire/ValueSerializers/Int16Serializer.cs
+++ b/Wire/ValueSerializers/Int16Serializer.cs
@@ -1,33 +1,24 @@
 using System;
 using System.IO;
-using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
-    public class Int16Serializer : ValueSerializer
+    public class Int16Serializer : SessionAwareValueSerializer<short>
     {
         public const byte Manifest = 3;
         public const int Size = sizeof(short);
         public static readonly Int16Serializer Instance = new Int16Serializer();
+
+        public Int16Serializer() : base(() => WriteValueImpl)
+        {
+        }
 
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
         }
 
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var sh = (short) value;
-            WriteValueImpl(stream, session, sh);
-        }
-
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, session, fieldValue);
-        }
-
-        public static void WriteValueImpl(Stream stream, SerializerSession session, short sh)
+        public static void WriteValueImpl(Stream stream, short sh, SerializerSession session)
         {
             var bytes = NoAllocBitConverter.GetBytes(sh, session);
             stream.Write(bytes, 0, Size);
@@ -38,11 +29,6 @@ namespace Wire.ValueSerializers
             var buffer = session.GetBuffer(Size);
             stream.Read(buffer, 0, Size);
             return BitConverter.ToInt16(buffer, 0);
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(short);
         }
     }
 }

--- a/Wire/ValueSerializers/Int16Serializer.cs
+++ b/Wire/ValueSerializers/Int16Serializer.cs
@@ -9,13 +9,8 @@ namespace Wire.ValueSerializers
         public const int Size = sizeof(short);
         public static readonly Int16Serializer Instance = new Int16Serializer();
 
-        public Int16Serializer() : base(() => WriteValueImpl)
+        public Int16Serializer() : base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         public static void WriteValueImpl(Stream stream, short sh, SerializerSession session)

--- a/Wire/ValueSerializers/Int16Serializer.cs
+++ b/Wire/ValueSerializers/Int16Serializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
@@ -16,7 +17,19 @@ namespace Wire.ValueSerializers
 
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
-            var bytes = NoAllocBitConverter.GetBytes((short) value, session);
+            var sh = (short) value;
+            WriteValueImpl(stream, session, sh);
+        }
+
+        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var method = GetType().GetMethod(nameof(WriteValueImpl));
+            c.EmitStaticCall(method, stream, session, fieldValue);
+        }
+
+        public static void WriteValueImpl(Stream stream, SerializerSession session, short sh)
+        {
+            var bytes = NoAllocBitConverter.GetBytes(sh, session);
             stream.Write(bytes, 0, Size);
         }
 

--- a/Wire/ValueSerializers/Int32Serializer.cs
+++ b/Wire/ValueSerializers/Int32Serializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
@@ -16,7 +17,19 @@ namespace Wire.ValueSerializers
 
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
-            var bytes = NoAllocBitConverter.GetBytes((int) value, session);
+            var i = (int) value;
+            WriteValueImpl(stream, session, i);
+        }
+
+        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var method = GetType().GetMethod(nameof(WriteValueImpl));
+            c.EmitStaticCall(method, stream, session, fieldValue);
+        }
+        
+        public static void WriteValueImpl(Stream stream, SerializerSession session, int i)
+        {
+            var bytes = NoAllocBitConverter.GetBytes(i, session);
             stream.Write(bytes, 0, Size);
         }
 

--- a/Wire/ValueSerializers/Int32Serializer.cs
+++ b/Wire/ValueSerializers/Int32Serializer.cs
@@ -1,33 +1,25 @@
 using System;
 using System.IO;
-using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
-    public class Int32Serializer : ValueSerializer
+    public class Int32Serializer : SessionAwareValueSerializer<int>
     {
         public const byte Manifest = 8;
         public const int Size = sizeof(int);
         public static readonly Int32Serializer Instance = new Int32Serializer();
+
+        public Int32Serializer()
+            : base(() => WriteValueImpl)
+        {
+        }
 
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
         }
 
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var i = (int) value;
-            WriteValueImpl(stream, session, i);
-        }
-
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, session, fieldValue);
-        }
-        
-        public static void WriteValueImpl(Stream stream, SerializerSession session, int i)
+        public static void WriteValueImpl(Stream stream, int i, SerializerSession session)
         {
             var bytes = NoAllocBitConverter.GetBytes(i, session);
             stream.Write(bytes, 0, Size);
@@ -38,11 +30,6 @@ namespace Wire.ValueSerializers
             var buffer = session.GetBuffer(Size);
             stream.Read(buffer, 0, Size);
             return BitConverter.ToInt32(buffer, 0);
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(int);
         }
     }
 }

--- a/Wire/ValueSerializers/Int32Serializer.cs
+++ b/Wire/ValueSerializers/Int32Serializer.cs
@@ -10,13 +10,8 @@ namespace Wire.ValueSerializers
         public static readonly Int32Serializer Instance = new Int32Serializer();
 
         public Int32Serializer()
-            : base(() => WriteValueImpl)
+            : base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         public static void WriteValueImpl(Stream stream, int i, SerializerSession session)

--- a/Wire/ValueSerializers/Int64Serializer.cs
+++ b/Wire/ValueSerializers/Int64Serializer.cs
@@ -1,33 +1,24 @@
 using System;
 using System.IO;
-using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
-    public class Int64Serializer : ValueSerializer
+    public class Int64Serializer : SessionAwareValueSerializer<long>
     {
         public const byte Manifest = 2;
         public const int Size = sizeof(long);
         public static readonly Int64Serializer Instance = new Int64Serializer();
+
+        public Int64Serializer() : base(()=>WriteValueImpl)
+        {
+        }
 
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
         }
 
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var l = (long) value;
-            WriteValueImpl(stream, session, l);
-        }
-
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, session, fieldValue);
-        }
-
-        public static void WriteValueImpl(Stream stream, SerializerSession session, long l)
+        public static void WriteValueImpl(Stream stream, long l, SerializerSession session)
         {
             var bytes = NoAllocBitConverter.GetBytes(l, session);
             stream.Write(bytes, 0, Size);
@@ -38,11 +29,6 @@ namespace Wire.ValueSerializers
             var buffer = session.GetBuffer(Size);
             stream.Read(buffer, 0, Size);
             return BitConverter.ToInt64(buffer, 0);
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(long);
         }
     }
 }

--- a/Wire/ValueSerializers/Int64Serializer.cs
+++ b/Wire/ValueSerializers/Int64Serializer.cs
@@ -9,13 +9,8 @@ namespace Wire.ValueSerializers
         public const int Size = sizeof(long);
         public static readonly Int64Serializer Instance = new Int64Serializer();
 
-        public Int64Serializer() : base(()=>WriteValueImpl)
+        public Int64Serializer() : base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         public static void WriteValueImpl(Stream stream, long l, SerializerSession session)

--- a/Wire/ValueSerializers/Int64Serializer.cs
+++ b/Wire/ValueSerializers/Int64Serializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
@@ -16,7 +17,19 @@ namespace Wire.ValueSerializers
 
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
-            var bytes = NoAllocBitConverter.GetBytes((long) value, session);
+            var l = (long) value;
+            WriteValueImpl(stream, session, l);
+        }
+
+        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var method = GetType().GetMethod(nameof(WriteValueImpl));
+            c.EmitStaticCall(method, stream, session, fieldValue);
+        }
+
+        public static void WriteValueImpl(Stream stream, SerializerSession session, long l)
+        {
+            var bytes = NoAllocBitConverter.GetBytes(l, session);
             stream.Write(bytes, 0, Size);
         }
 

--- a/Wire/ValueSerializers/SByteSerializer.cs
+++ b/Wire/ValueSerializers/SByteSerializer.cs
@@ -7,13 +7,8 @@ namespace Wire.ValueSerializers
         public const byte Manifest = 20;
         public static readonly SByteSerializer Instance = new SByteSerializer();
 
-        public SByteSerializer() : base(() => WriteValueImpl)
+        public SByteSerializer() : base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         public static unsafe void WriteValueImpl(Stream stream, sbyte @sbyte)

--- a/Wire/ValueSerializers/SByteSerializer.cs
+++ b/Wire/ValueSerializers/SByteSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
@@ -13,9 +14,20 @@ namespace Wire.ValueSerializers
             stream.WriteByte(Manifest);
         }
 
-        public override unsafe void WriteValue(Stream stream, object value, SerializerSession session)
+        public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
             var @sbyte = (sbyte) value;
+            WriteValueImpl(stream, @sbyte);
+        }
+
+        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var method = GetType().GetMethod(nameof(WriteValueImpl));
+            c.EmitStaticCall(method, stream, fieldValue);
+        }
+
+        public static unsafe void WriteValueImpl(Stream stream, sbyte @sbyte)
+        {
             stream.WriteByte(*(byte*) &@sbyte);
         }
 

--- a/Wire/ValueSerializers/SByteSerializer.cs
+++ b/Wire/ValueSerializers/SByteSerializer.cs
@@ -1,29 +1,19 @@
-﻿using System;
-using System.IO;
-using Wire.ExpressionDSL;
+﻿using System.IO;
 
 namespace Wire.ValueSerializers
 {
-    public class SByteSerializer : ValueSerializer
+    public class SByteSerializer : SessionIgnorantValueSerializer<sbyte>
     {
         public const byte Manifest = 20;
         public static readonly SByteSerializer Instance = new SByteSerializer();
 
+        public SByteSerializer() : base(() => WriteValueImpl)
+        {
+        }
+
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
-        }
-
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var @sbyte = (sbyte) value;
-            WriteValueImpl(stream, @sbyte);
-        }
-
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, fieldValue);
         }
 
         public static unsafe void WriteValueImpl(Stream stream, sbyte @sbyte)
@@ -35,11 +25,6 @@ namespace Wire.ValueSerializers
         {
             var @byte = (byte) stream.ReadByte();
             return *(sbyte*) &@byte;
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(sbyte);
         }
     }
 }

--- a/Wire/ValueSerializers/SessionAwareValueSerializer.cs
+++ b/Wire/ValueSerializers/SessionAwareValueSerializer.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Linq.Expressions;
+using System.Reflection;
+using Wire.ExpressionDSL;
+
+namespace Wire.ValueSerializers
+{
+    public abstract class SessionAwareValueSerializer<TElementType> : ValueSerializer
+    {
+        private readonly MethodInfo _write;
+        private readonly Action<Stream, object, SerializerSession> _writeCompiled;
+
+        protected SessionAwareValueSerializer(
+            Expression<Func<Action<Stream, TElementType, SerializerSession>>> writeStaticMethod)
+        {
+            _write = GetStaticVoid(writeStaticMethod);
+
+            var stream = Expression.Parameter(typeof(Stream));
+            var value = Expression.Parameter(typeof(object));
+            var session = Expression.Parameter(typeof(SerializerSession));
+
+            _writeCompiled = Expression.Lambda<Action<Stream, object, SerializerSession>>(
+                Expression.Call(_write, stream, Expression.Convert(value, typeof(TElementType)), session), stream, value,
+                session).Compile();
+        }
+
+        public sealed override void WriteValue(Stream stream, object value, SerializerSession session)
+        {
+            _writeCompiled(stream, value, session);
+        }
+
+        public sealed override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            c.EmitStaticCall(_write, stream, fieldValue, session);
+        }
+
+        public sealed override Type GetElementType()
+        {
+            return typeof(TElementType);
+        }
+    }
+}

--- a/Wire/ValueSerializers/SessionAwareValueSerializer.cs
+++ b/Wire/ValueSerializers/SessionAwareValueSerializer.cs
@@ -8,12 +8,14 @@ namespace Wire.ValueSerializers
 {
     public abstract class SessionAwareValueSerializer<TElementType> : ValueSerializer
     {
+        private readonly byte _manifest;
         private readonly MethodInfo _write;
         private readonly Action<Stream, object, SerializerSession> _writeCompiled;
 
-        protected SessionAwareValueSerializer(
+        protected SessionAwareValueSerializer(byte manifest,
             Expression<Func<Action<Stream, TElementType, SerializerSession>>> writeStaticMethod)
         {
+            _manifest = manifest;
             _write = GetStaticVoid(writeStaticMethod);
 
             var stream = Expression.Parameter(typeof(Stream));
@@ -23,6 +25,11 @@ namespace Wire.ValueSerializers
             _writeCompiled = Expression.Lambda<Action<Stream, object, SerializerSession>>(
                 Expression.Call(_write, stream, Expression.Convert(value, typeof(TElementType)), session), stream, value,
                 session).Compile();
+        }
+
+        public sealed override void WriteManifest(Stream stream, SerializerSession session)
+        {
+            stream.WriteByte(_manifest);
         }
 
         public sealed override void WriteValue(Stream stream, object value, SerializerSession session)

--- a/Wire/ValueSerializers/SessionIgnorantValueSerializer.cs
+++ b/Wire/ValueSerializers/SessionIgnorantValueSerializer.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using System.Linq.Expressions;
+using System.Reflection;
+using Wire.ExpressionDSL;
+
+namespace Wire.ValueSerializers
+{
+    public abstract class SessionIgnorantValueSerializer<TElementType> : ValueSerializer
+    {
+        private readonly MethodInfo _write;
+        private readonly Action<Stream, object> _writeCompiled;
+
+        protected SessionIgnorantValueSerializer(
+            Expression<Func<Action<Stream, TElementType>>> writeStaticMethod)
+        {
+            _write = GetStaticVoid(writeStaticMethod);
+
+            var stream = Expression.Parameter(typeof(Stream));
+            var value = Expression.Parameter(typeof(object));
+
+            _writeCompiled = Expression.Lambda<Action<Stream, object>>(
+                Expression.Call(_write, stream, Expression.Convert(value, typeof(TElementType))), stream, value)
+                .Compile();
+        }
+
+        public sealed override void WriteValue(Stream stream, object value, SerializerSession session)
+        {
+            _writeCompiled(stream, value);
+        }
+
+        public sealed override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            c.EmitStaticCall(_write, stream, fieldValue);
+        }
+
+        public sealed override Type GetElementType()
+        {
+            return typeof(TElementType);
+        }
+    }
+}

--- a/Wire/ValueSerializers/StringSerializer.cs
+++ b/Wire/ValueSerializers/StringSerializer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Text;
 
 namespace Wire.ValueSerializers
 {

--- a/Wire/ValueSerializers/UInt16Serializer.cs
+++ b/Wire/ValueSerializers/UInt16Serializer.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
     public class UInt16Serializer : ValueSerializer
     {
         public const byte Manifest = 17;
-        public const int Size = sizeof (ushort);
+        public const int Size = sizeof(ushort);
         public static readonly UInt16Serializer Instance = new UInt16Serializer();
 
         public override void WriteManifest(Stream stream, SerializerSession session)
@@ -16,7 +17,19 @@ namespace Wire.ValueSerializers
 
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
-            var bytes = NoAllocBitConverter.GetBytes((ushort) value, session);
+            var u = (ushort) value;
+            WriteValueImpl(stream, session, u);
+        }
+
+        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var method = GetType().GetMethod(nameof(WriteValueImpl));
+            c.EmitStaticCall(method, stream, session, fieldValue);
+        }
+
+        public static void WriteValueImpl(Stream stream, SerializerSession session, ushort u)
+        {
+            var bytes = NoAllocBitConverter.GetBytes(u, session);
             stream.Write(bytes, 0, Size);
         }
 
@@ -29,7 +42,7 @@ namespace Wire.ValueSerializers
 
         public override Type GetElementType()
         {
-            return typeof (ushort);
+            return typeof(ushort);
         }
     }
 }

--- a/Wire/ValueSerializers/UInt16Serializer.cs
+++ b/Wire/ValueSerializers/UInt16Serializer.cs
@@ -1,33 +1,24 @@
 ﻿using System;
 using System.IO;
-using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
-    public class UInt16Serializer : ValueSerializer
+    public class UInt16Serializer : SessionAwareValueSerializer<ushort>
     {
         public const byte Manifest = 17;
         public const int Size = sizeof(ushort);
         public static readonly UInt16Serializer Instance = new UInt16Serializer();
+
+        public UInt16Serializer() : base(() => WriteValueImpl)
+        {
+        }
 
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
         }
 
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var u = (ushort) value;
-            WriteValueImpl(stream, session, u);
-        }
-
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, session, fieldValue);
-        }
-
-        public static void WriteValueImpl(Stream stream, SerializerSession session, ushort u)
+        public static void WriteValueImpl(Stream stream, ushort u, SerializerSession session)
         {
             var bytes = NoAllocBitConverter.GetBytes(u, session);
             stream.Write(bytes, 0, Size);
@@ -38,11 +29,6 @@ namespace Wire.ValueSerializers
             var buffer = session.GetBuffer(Size);
             stream.Read(buffer, 0, Size);
             return BitConverter.ToUInt16(buffer, 0);
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(ushort);
         }
     }
 }

--- a/Wire/ValueSerializers/UInt16Serializer.cs
+++ b/Wire/ValueSerializers/UInt16Serializer.cs
@@ -9,13 +9,8 @@ namespace Wire.ValueSerializers
         public const int Size = sizeof(ushort);
         public static readonly UInt16Serializer Instance = new UInt16Serializer();
 
-        public UInt16Serializer() : base(() => WriteValueImpl)
+        public UInt16Serializer() : base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         public static void WriteValueImpl(Stream stream, ushort u, SerializerSession session)

--- a/Wire/ValueSerializers/UInt32Serializer.cs
+++ b/Wire/ValueSerializers/UInt32Serializer.cs
@@ -9,13 +9,8 @@ namespace Wire.ValueSerializers
         public const int Size = sizeof(uint);
         public static readonly UInt32Serializer Instance = new UInt32Serializer();
 
-        public UInt32Serializer() : base(() => WriteValueImpl)
+        public UInt32Serializer() : base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         public static void WriteValueImpl(Stream stream, uint u, SerializerSession session)

--- a/Wire/ValueSerializers/UInt32Serializer.cs
+++ b/Wire/ValueSerializers/UInt32Serializer.cs
@@ -1,33 +1,24 @@
 ﻿using System;
 using System.IO;
-using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
-    public class UInt32Serializer : ValueSerializer
+    public class UInt32Serializer : SessionAwareValueSerializer<uint>
     {
         public const byte Manifest = 18;
         public const int Size = sizeof(uint);
         public static readonly UInt32Serializer Instance = new UInt32Serializer();
+
+        public UInt32Serializer() : base(() => WriteValueImpl)
+        {
+        }
 
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
         }
 
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var u = (uint) value;
-            WriteValueImpl(stream, session, u);
-        }
-
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, session, fieldValue);
-        }
-
-        public static void WriteValueImpl(Stream stream, SerializerSession session, uint u)
+        public static void WriteValueImpl(Stream stream, uint u, SerializerSession session)
         {
             var bytes = NoAllocBitConverter.GetBytes(u, session);
             stream.Write(bytes, 0, Size);
@@ -38,11 +29,6 @@ namespace Wire.ValueSerializers
             var buffer = session.GetBuffer(Size);
             stream.Read(buffer, 0, Size);
             return BitConverter.ToUInt32(buffer, 0);
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(uint);
         }
     }
 }

--- a/Wire/ValueSerializers/UInt32Serializer.cs
+++ b/Wire/ValueSerializers/UInt32Serializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
@@ -16,7 +17,19 @@ namespace Wire.ValueSerializers
 
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
-            var bytes = NoAllocBitConverter.GetBytes((uint) value, session);
+            var u = (uint) value;
+            WriteValueImpl(stream, session, u);
+        }
+
+        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var method = GetType().GetMethod(nameof(WriteValueImpl));
+            c.EmitStaticCall(method, stream, session, fieldValue);
+        }
+
+        public static void WriteValueImpl(Stream stream, SerializerSession session, uint u)
+        {
+            var bytes = NoAllocBitConverter.GetBytes(u, session);
             stream.Write(bytes, 0, Size);
         }
 

--- a/Wire/ValueSerializers/UInt64Serializer.cs
+++ b/Wire/ValueSerializers/UInt64Serializer.cs
@@ -1,33 +1,24 @@
 ﻿using System;
 using System.IO;
-using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
-    public class UInt64Serializer : ValueSerializer
+    public class UInt64Serializer : SessionAwareValueSerializer<ulong>
     {
         public const byte Manifest = 19;
         public const int Size = sizeof(ulong);
         public static readonly UInt64Serializer Instance = new UInt64Serializer();
+
+        public UInt64Serializer() : base(() => WriteValueImpl)
+        {
+        }
 
         public override void WriteManifest(Stream stream, SerializerSession session)
         {
             stream.WriteByte(Manifest);
         }
 
-        public override void WriteValue(Stream stream, object value, SerializerSession session)
-        {
-            var ul = (ulong) value;
-            WriteValueImpl(stream, session, ul);
-        }
-
-        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
-        {
-            var method = GetType().GetMethod(nameof(WriteValueImpl));
-            c.EmitStaticCall(method, stream, session, fieldValue);
-        }
-
-        public static void WriteValueImpl(Stream stream, SerializerSession session, ulong ul)
+        public static void WriteValueImpl(Stream stream, ulong ul, SerializerSession session)
         {
             var bytes = NoAllocBitConverter.GetBytes(ul, session);
             stream.Write(bytes, 0, Size);
@@ -38,11 +29,6 @@ namespace Wire.ValueSerializers
             var buffer = session.GetBuffer(Size);
             stream.Read(buffer, 0, Size);
             return BitConverter.ToUInt64(buffer, 0);
-        }
-
-        public override Type GetElementType()
-        {
-            return typeof(ulong);
         }
     }
 }

--- a/Wire/ValueSerializers/UInt64Serializer.cs
+++ b/Wire/ValueSerializers/UInt64Serializer.cs
@@ -9,13 +9,8 @@ namespace Wire.ValueSerializers
         public const int Size = sizeof(ulong);
         public static readonly UInt64Serializer Instance = new UInt64Serializer();
 
-        public UInt64Serializer() : base(() => WriteValueImpl)
+        public UInt64Serializer() : base(Manifest, () => WriteValueImpl)
         {
-        }
-
-        public override void WriteManifest(Stream stream, SerializerSession session)
-        {
-            stream.WriteByte(Manifest);
         }
 
         public static void WriteValueImpl(Stream stream, ulong ul, SerializerSession session)

--- a/Wire/ValueSerializers/UInt64Serializer.cs
+++ b/Wire/ValueSerializers/UInt64Serializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
@@ -16,7 +17,19 @@ namespace Wire.ValueSerializers
 
         public override void WriteValue(Stream stream, object value, SerializerSession session)
         {
-            var bytes = NoAllocBitConverter.GetBytes((ulong) value, session);
+            var ul = (ulong) value;
+            WriteValueImpl(stream, session, ul);
+        }
+
+        public override void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var method = GetType().GetMethod(nameof(WriteValueImpl));
+            c.EmitStaticCall(method, stream, session, fieldValue);
+        }
+
+        public static void WriteValueImpl(Stream stream, SerializerSession session, ulong ul)
+        {
+            var bytes = NoAllocBitConverter.GetBytes(ul, session);
             stream.Write(bytes, 0, Size);
         }
 

--- a/Wire/ValueSerializers/ValueSerializer.cs
+++ b/Wire/ValueSerializers/ValueSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
 {
@@ -9,5 +10,15 @@ namespace Wire.ValueSerializers
         public abstract void WriteValue(Stream stream, object value, SerializerSession session);
         public abstract object ReadValue(Stream stream, DeserializerSession session);
         public abstract Type GetElementType();
+
+        public virtual void EmitWriteValue(Compiler<ObjectWriter> c, int stream, int fieldValue, int session)
+        {
+            var converted = c.ConvertTo<object>(fieldValue);
+            var method = typeof(ValueSerializer).GetMethod(nameof(WriteValue));
+
+            //write it to the value serializer
+            var vs = c.Constant(this);
+            c.EmitCall(method, vs, stream, converted, session);
+        }
     }
 }

--- a/Wire/ValueSerializers/ValueSerializer.cs
+++ b/Wire/ValueSerializers/ValueSerializer.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Linq.Expressions;
+using System.Reflection;
 using Wire.ExpressionDSL;
 
 namespace Wire.ValueSerializers
@@ -19,6 +21,26 @@ namespace Wire.ValueSerializers
             //write it to the value serializer
             var vs = c.Constant(this);
             c.EmitCall(method, vs, stream, converted, session);
+        }
+
+        public static MethodInfo GetStaticVoid(LambdaExpression expression)
+        {
+            var unaryExpression = (UnaryExpression) expression.Body;
+            var methodCallExpression = (MethodCallExpression) unaryExpression.Operand;
+            var methodCallObject = (ConstantExpression) methodCallExpression.Object;
+            var method = (MethodInfo) methodCallObject.Value;
+
+            if (method.IsStatic == false)
+            {
+                throw new ArgumentException($"Method {method.Name} should be static.");
+            }
+
+            if (method.ReturnType != typeof(void))
+            {
+                throw new ArgumentException($"Method {method.Name} should return void.");
+            }
+
+            return method;
         }
     }
 }

--- a/Wire/Wire.csproj
+++ b/Wire/Wire.csproj
@@ -92,6 +92,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SerializerSession.cs" />
     <Compile Include="ValueSerializers\SByteSerializer.cs" />
+    <Compile Include="ValueSerializers\SessionAwareValueSerializer.cs" />
+    <Compile Include="ValueSerializers\SessionIgnorantValueSerializer.cs" />
     <Compile Include="ValueSerializers\StringSerializer.cs" />
     <Compile Include="ValueSerializers\ToSurrogateSerializer.cs" />
     <Compile Include="ValueSerializers\TypeSerializer.cs" />


### PR DESCRIPTION
Should be merged after the fix provided in #51 

This PR provides a better emit capabilities for the serialization part. It delegates emission of the `WriteObject` to the `ValueSerializer` allowing overloading in the primitives.
