### PR TITLE
Use a custom comparer to prevent boxing

### DIFF
--- a/Wire/ByteArrayKeyComparer.cs
+++ b/Wire/ByteArrayKeyComparer.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace Wire
+{
+    /// <summary>
+    /// By default ByteArrayKey overrides "public bool Equals(object obj)" to do comparisions.
+    /// But this causes boxing/allocations, so by having a custom comparer we can prevent that.
+    /// </summary>
+    public class ByteArrayKeyComparer : IEqualityComparer<ByteArrayKey>
+    {
+        public static readonly ByteArrayKeyComparer Instance = new ByteArrayKeyComparer();
+
+        public bool Equals(ByteArrayKey x, ByteArrayKey y)
+        {
+            return ByteArrayKey.Compare(x.Bytes, y.Bytes);
+        }
+
+        public int GetHashCode(ByteArrayKey obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/Wire/Extensions/TypeEx.cs
+++ b/Wire/Extensions/TypeEx.cs
@@ -87,7 +87,7 @@ namespace Wire.Extensions
         }
 
         private static readonly ConcurrentDictionary<ByteArrayKey, Type> TypeNameLookup =
-            new ConcurrentDictionary<ByteArrayKey, Type>();
+            new ConcurrentDictionary<ByteArrayKey, Type>(ByteArrayKeyComparer.Instance);
 
         public static byte[] GetTypeManifest(IReadOnlyCollection<byte[]> fieldNames)
         {

--- a/Wire/Wire.csproj
+++ b/Wire/Wire.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="Annotations.cs" />
     <Compile Include="ByteArrayKey.cs" />
+    <Compile Include="ByteArrayKeyComparer.cs" />
     <Compile Include="Compilation\ExpressionEx.cs" />
     <Compile Include="Compilation\IlCompiler.cs" />
     <Compile Include="Compilation\IlBuilder.cs" />


### PR DESCRIPTION
For full benchmark and results see [this gist](https://gist.github.com/mattwarren/da62343df8fbdc5378df21e49df6a7c3), but in summary:

![image](https://cloud.githubusercontent.com/assets/157298/17805974/f11b8454-65f9-11e6-9140-5739a7bab319.png)
