### PR TITLE
Direct byte chunk serialization

### DIFF
--- a/Wire/ByteChunk.cs
+++ b/Wire/ByteChunk.cs
@@ -1,0 +1,14 @@
+﻿namespace Wire
+{
+    public unsafe struct ByteChunk
+    {
+        public byte* Start;
+        public readonly byte* End;
+
+        public ByteChunk(byte* start, byte* end)
+        {
+            Start = start;
+            End = end;
+        }
+    }
+}

--- a/Wire/ValueSerializers/BoolSerializer.cs
+++ b/Wire/ValueSerializers/BoolSerializer.cs
@@ -8,13 +8,20 @@ namespace Wire.ValueSerializers
         public static readonly BoolSerializer Instance = new BoolSerializer();
 
         public BoolSerializer() :
-            base(Manifest, () => WriteValueImpl, () => ReadValueImpl)
+            base(Manifest, () => WriteValueImpl, () => ReadValueImpl, () => ReadChunkValueImpl)
         {
         }
 
         public static bool ReadValueImpl(Stream stream)
         {
             var b = stream.ReadByte();
+            return b != 0;
+        }
+
+        public static unsafe bool ReadChunkValueImpl(ref ByteChunk chunk)
+        {
+            var b = *chunk.Start;
+            chunk.Start += 1;
             return b != 0;
         }
 

--- a/Wire/ValueSerializers/ByteSerializer.cs
+++ b/Wire/ValueSerializers/ByteSerializer.cs
@@ -7,13 +7,20 @@ namespace Wire.ValueSerializers
         public const byte Manifest = 4;
         public static readonly ByteSerializer Instance = new ByteSerializer();
 
-        public ByteSerializer() : base(Manifest, () => WriteValueImpl, () => ReadValueImpl)
+        public ByteSerializer() : base(Manifest, () => WriteValueImpl, () => ReadValueImpl, () => ReadChunkValueImpl)
         {
         }
 
         public static void WriteValueImpl(Stream stream, byte b)
         {
             stream.WriteByte(b);
+        }
+
+        public static unsafe byte ReadChunkValueImpl(ref ByteChunk chunk)
+        {
+            var b = *chunk.Start;
+            chunk.Start += 1;
+            return b;
         }
 
         public static byte ReadValueImpl(Stream stream)

--- a/Wire/ValueSerializers/ReadChunk.cs
+++ b/Wire/ValueSerializers/ReadChunk.cs
@@ -1,0 +1,5 @@
+namespace Wire.ValueSerializers
+{
+    // ReSharper disable once TypeParameterCanBeVariant
+    public delegate TElementType ReadChunk<TElementType>(ref ByteChunk chunk);
+}

--- a/Wire/ValueSerializers/ValueSerializer.cs
+++ b/Wire/ValueSerializers/ValueSerializer.cs
@@ -12,6 +12,19 @@ namespace Wire.ValueSerializers
         public abstract void WriteManifest([NotNull] Stream stream, [NotNull] SerializerSession session);
         public abstract void WriteValue([NotNull] Stream stream, object value, [NotNull] SerializerSession session);
         public abstract object ReadValue([NotNull] Stream stream, [NotNull] DeserializerSession session);
+
+        public abstract object ReadValue(ref ByteChunk chunk);
+
+        public virtual int EmitReadValueFromChunk([NotNull] ICompiler<ObjectReader> c, int chunk,
+            [NotNull] FieldInfo field)
+        {
+            var method = typeof(ValueSerializer).GetTypeInfo().GetMethod(nameof(ReadValue));
+            var ss = c.Constant(this);
+            var read = c.Call(method, ss, chunk);
+            read = c.Convert(read, field.FieldType);
+            return read;
+        }
+
         public abstract Type GetElementType();
 
         public virtual void EmitWriteValue(ICompiler<ObjectWriter> c, int stream, int fieldValue, int session)

--- a/Wire/Wire.csproj
+++ b/Wire/Wire.csproj
@@ -45,6 +45,7 @@
     <Compile Include="Annotations.cs" />
     <Compile Include="ByteArrayKey.cs" />
     <Compile Include="ByteArrayKeyComparer.cs" />
+    <Compile Include="ByteChunk.cs" />
     <Compile Include="Compilation\ExpressionEx.cs" />
     <Compile Include="Compilation\IlCompiler.cs" />
     <Compile Include="Compilation\IlBuilder.cs" />
@@ -96,6 +97,7 @@
     <Compile Include="Serializer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SerializerSession.cs" />
+    <Compile Include="ValueSerializers\ReadChunk.cs" />
     <Compile Include="ValueSerializers\SByteSerializer.cs" />
     <Compile Include="ValueSerializers\SessionAwareByteArrayRequiringValueSerializer.cs" />
     <Compile Include="ValueSerializers\SessionIgnorantValueSerializer.cs" />


### PR DESCRIPTION
Should we consider providing direct `byte*` serialization/deserialization? That could increase the overhead of writing code twice, but could be managed by extracting some methods as well.

Would you see a place for this @rogeralsing ?

This PR is just a sketch to provide some implementation showing what I mean.
