### PR TITLE
Correct bad increment size and enable unchecked.

### DIFF
--- a/Wire/ByteArrayKey.cs
+++ b/Wire/ByteArrayKey.cs
@@ -20,12 +20,15 @@ namespace Wire
 
         private static int GetHashCode([NotNull] byte[] bytes)
         {
-            var hash = 17;
-            for (var i = 0; i < bytes.Length; i += 5)
+            unchecked
             {
-                hash = hash*23 + bytes[i];
+                var hash = 17;
+                for (var i = 0; i < bytes.Length; i++)
+                {
+                    hash = hash*23 + bytes[i];
+                }
+                return hash;
             }
-            return hash;
         }
 
         public ByteArrayKey(byte[] bytes)


### PR DESCRIPTION
Currently the hashcode in ByteArrayKey is only calculated from every fifth byte, I don't know why.
Fix it and enable unchecked (as e.g. Jon Skeet recommends)
