### PR TITLE
C# LINQ expression serialization

### DIFF
--- a/Wire.FSharpTestTypes/Library1.fs
+++ b/Wire.FSharpTestTypes/Library1.fs
@@ -38,5 +38,11 @@ type User =
             | :? User as y -> compare x.name y.name
             | _ -> invalidArg "yobj" "cannot compare values of different types"
 
-
+module TestQuotations = 
+    let Quotation = <@ fun (x:int) -> 
+        let rec fib n = 
+            match n with
+            | 0 | 1 -> 1
+            | _ -> fib(n-1) + fib(n-2)
+        async { return fib x } @>
 

--- a/Wire.Tests/ExpressionTests.cs
+++ b/Wire.Tests/ExpressionTests.cs
@@ -1,0 +1,499 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Wire.Tests
+{
+    [TestClass]
+    public class ExpressionTests
+    {
+        public struct Dummy
+        {
+            public string TestField;
+            public int TestProperty { get; set; }
+            public string TestMethod(string input) => input;
+
+            public Dummy(string testField) : this()
+            {
+                TestField = testField;
+            }
+        }
+
+        public class DummyException : Exception
+        {
+            protected DummyException(
+                SerializationInfo info,
+                StreamingContext context) : base(info, context)
+            {
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeFieldInfo()
+        {
+            var fieldInfo = typeof(Dummy).GetField("TestField");
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(fieldInfo, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<FieldInfo>(stream);
+                Assert.AreEqual(fieldInfo, deserialized);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializePropertyInfo()
+        {
+            var propertyInfo = typeof(Dummy).GetProperty("TestProperty");
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(propertyInfo, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<PropertyInfo>(stream);
+                Assert.AreEqual(propertyInfo, deserialized);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeMethodInfo()
+        {
+            var methodInfo = typeof(Dummy).GetMethod("TestMethod");
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(methodInfo, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<MethodInfo>(stream);
+                Assert.AreEqual(methodInfo, deserialized);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeSymbolDocumentInfo()
+        {
+            var info = Expression.SymbolDocument("testFile");
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(info, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<SymbolDocumentInfo>(stream);
+                Assert.AreEqual(info.FileName, deserialized.FileName);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeConstructorInfo()
+        {
+            var constructorInfo = typeof(Dummy).GetConstructor(new[] { typeof(string) });
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(constructorInfo, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<ConstructorInfo>(stream);
+                Assert.AreEqual(constructorInfo, deserialized);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeConstantExpression()
+        {
+            var expr = Expression.Constant(12);
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<ConstantExpression>(stream);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Value, deserialized.Value);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeUnaryExpression()
+        {
+            var expr = Expression.Decrement(Expression.Constant(1));
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<UnaryExpression>(stream);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.Method, deserialized.Method);
+                Assert.AreEqual(expr.Operand.ConstantValue(), deserialized.Operand.ConstantValue());
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeBinaryExpression()
+        {
+            var expr = Expression.Add(Expression.Constant(1), Expression.Constant(2));
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<BinaryExpression>(stream);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Method, deserialized.Method);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeIndexExpression()
+        {
+            var value = new[] {1, 2, 3};
+            var arrayExpr = Expression.Constant(value);
+            var expr = Expression.ArrayAccess(arrayExpr, Expression.Constant(1));
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<IndexExpression>(stream);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.Indexer, deserialized.Indexer);
+                Assert.AreEqual(1, deserialized.Arguments.Count);
+                Assert.AreEqual(expr.Arguments[0].ConstantValue(), deserialized.Arguments[0].ConstantValue());
+                var actual = (int[])deserialized.Object.ConstantValue();
+                Assert.AreEqual(value[0], actual[0]);
+                Assert.AreEqual(value[1], actual[1]);
+                Assert.AreEqual(value[2], actual[2]);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeMemberAssignment()
+        {
+            var property = typeof(Dummy).GetProperty("TestProperty");
+            var expr = Expression.Bind(property.SetMethod, Expression.Constant(9));
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<MemberAssignment>(stream);
+                Assert.AreEqual(expr.BindingType, deserialized.BindingType);
+                Assert.AreEqual(expr.Member, deserialized.Member);
+                Assert.AreEqual(expr.Expression.ConstantValue(), deserialized.Expression.ConstantValue());
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeConditionalExpression()
+        {
+            var expr = Expression.Condition(Expression.Constant(true), Expression.Constant(1), Expression.Constant(2));
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<ConditionalExpression>(stream);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.Test.ConstantValue(), deserialized.Test.ConstantValue());
+                Assert.AreEqual(expr.IfTrue.ConstantValue(), deserialized.IfTrue.ConstantValue());
+                Assert.AreEqual(expr.IfFalse.ConstantValue(), deserialized.IfFalse.ConstantValue());
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeBlockExpression()
+        {
+            var expr = Expression.Block(new[] { Expression.Constant(1), Expression.Constant(2), Expression.Constant(3) });
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<BlockExpression>(stream);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.Expressions.Count, deserialized.Expressions.Count);
+                Assert.AreEqual(expr.Expressions[0].ConstantValue(), deserialized.Expressions[0].ConstantValue());
+                Assert.AreEqual(expr.Expressions[1].ConstantValue(), deserialized.Expressions[1].ConstantValue());
+                Assert.AreEqual(expr.Result.ConstantValue(), deserialized.Result.ConstantValue());
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeLabelTarget()
+        {
+            var label = Expression.Label(typeof(int), "testLabel");
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(label, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<LabelTarget>(stream);
+                Assert.AreEqual(label.Name, deserialized.Name);
+                Assert.AreEqual(label.Type, deserialized.Type);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeLabelExpression()
+        {
+            var label = Expression.Label(typeof(int), "testLabel");
+            var expr = Expression.Label(label, Expression.Constant(2));
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<LabelExpression>(stream);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Target.Name, deserialized.Target.Name);
+                Assert.AreEqual(expr.DefaultValue.ConstantValue(), deserialized.DefaultValue.ConstantValue());
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeMethodCallExpression()
+        {
+            var methodInfo = typeof(Dummy).GetMethod("TestMethod");
+            var expr = Expression.Call(Expression.Constant(new Dummy()), methodInfo, Expression.Constant("test string"));
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<MethodCallExpression>(stream);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Method, deserialized.Method);
+                Assert.AreEqual(expr.Object.ConstantValue(), deserialized.Object.ConstantValue());
+                Assert.AreEqual(1, deserialized.Arguments.Count);
+                Assert.AreEqual(expr.Arguments[0].ConstantValue(), deserialized.Arguments[0].ConstantValue());
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeDefaultExpression()
+        {
+            var expr = Expression.Default(typeof(int));
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<DefaultExpression>(stream);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeParameterExpression()
+        {
+            var expr = Expression.Parameter(typeof(int), "p1");
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<ParameterExpression>(stream);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Name, deserialized.Name);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeCatchBlock()
+        {
+            var expr = Expression.Catch(typeof(DummyException), Expression.Constant(2));
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<CatchBlock>(stream);
+                Assert.AreEqual(expr.Test, deserialized.Test);
+                Assert.AreEqual(expr.Body.ConstantValue(), deserialized.Body.ConstantValue());
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeGotoExpression()
+        {
+            var label = Expression.Label(typeof(void), "testLabel");
+            var expr = Expression.Continue(label);
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<GotoExpression>(stream);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.Kind, deserialized.Kind);
+                Assert.AreEqual(expr.Target.Name, deserialized.Target.Name);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeNewExpression()
+        {
+            var ctor = typeof(Dummy).GetConstructor(new[] { typeof(string) });
+            var expr = Expression.New(ctor, Expression.Constant("test param"));
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<NewExpression>(stream);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.Constructor, deserialized.Constructor);
+                Assert.AreEqual(expr.Arguments.Count, deserialized.Arguments.Count);
+                Assert.AreEqual(expr.Arguments[0].ConstantValue(), deserialized.Arguments[0].ConstantValue());
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeDebugInfoExpression()
+        {
+            var info = Expression.SymbolDocument("testFile");
+            var expr = Expression.DebugInfo(info, 1, 2, 3, 4);
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<DebugInfoExpression>(stream);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.Document.FileName, deserialized.Document.FileName);
+                Assert.AreEqual(expr.EndColumn, deserialized.EndColumn);
+                Assert.AreEqual(expr.StartColumn, deserialized.StartColumn);
+                Assert.AreEqual(expr.EndLine, deserialized.EndLine);
+                Assert.AreEqual(expr.StartLine, deserialized.StartLine);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeLambdaExpression()
+        {
+            var methodInfo = typeof(Dummy).GetMethod("TestMethod");
+            var param = Expression.Parameter(typeof (Dummy), "dummy");
+            var expr = Expression.Lambda(Expression.Call(param, methodInfo, Expression.Constant("s")), param);
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<LambdaExpression>(stream);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.Name, deserialized.Name);
+                Assert.AreEqual(expr.TailCall, deserialized.TailCall);
+                Assert.AreEqual(expr.ReturnType, deserialized.ReturnType);
+                Assert.AreEqual(expr.Parameters.Count, deserialized.Parameters.Count);
+                Assert.AreEqual(expr.Parameters[0].Name, deserialized.Parameters[0].Name);
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeInvocationExpression()
+        {
+            var methodInfo = typeof(Dummy).GetMethod("TestMethod");
+            var param = Expression.Parameter(typeof(Dummy), "dummy");
+            var lambda = Expression.Lambda(Expression.Call(param, methodInfo, Expression.Constant("s")), param);
+            var expr = Expression.Invoke(lambda, Expression.Constant(new Dummy()));
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<InvocationExpression>(stream);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.Arguments.Count, deserialized.Arguments.Count);
+                Assert.AreEqual(expr.Arguments[0].ConstantValue(), deserialized.Arguments[0].ConstantValue());
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeElementInit()
+        {
+            var listAddMethod = typeof (List<int>).GetMethod("Add");
+            var expr = Expression.ElementInit(listAddMethod, Expression.Constant(1));
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<ElementInit>(stream);
+                Assert.AreEqual(expr.AddMethod, deserialized.AddMethod);
+                Assert.AreEqual(1, deserialized.Arguments.Count);
+                Assert.AreEqual(expr.Arguments[0].ConstantValue(), deserialized.Arguments[0].ConstantValue());
+            }
+        }
+
+        [TestMethod]
+        public void CanSerializeLoopExpression()
+        {
+            var breakLabel = Expression.Label(typeof (void), "break");
+            var continueLabel = Expression.Label(typeof(void), "cont");
+            var expr = Expression.Loop(Expression.Constant(2), breakLabel, continueLabel);
+            var serializer = new Wire.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(expr, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<LoopExpression>(stream);
+                Assert.AreEqual(expr.NodeType, deserialized.NodeType);
+                Assert.AreEqual(expr.Type, deserialized.Type);
+                Assert.AreEqual(expr.Body.ConstantValue(), deserialized.Body.ConstantValue());
+                Assert.AreEqual(expr.BreakLabel.Name, deserialized.BreakLabel.Name);
+                Assert.AreEqual(expr.ContinueLabel.Name, deserialized.ContinueLabel.Name);
+            }
+        }
+    }
+
+    internal static class ExpressionExtensions
+    {
+        public static object ConstantValue(this Expression expr) => ((ConstantExpression)expr).Value;
+    }
+}

--- a/Wire.Tests/FSharpTests.cs
+++ b/Wire.Tests/FSharpTests.cs
@@ -3,6 +3,8 @@ using Microsoft.FSharp.Collections;
 using Microsoft.FSharp.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Wire.FSharpTestTypes;
+using Microsoft.FSharp.Quotations;
+using Microsoft.FSharp.Control;
 
 namespace Wire.Tests
 {
@@ -80,7 +82,19 @@ namespace Wire.Tests
                 Assert.AreEqual(expected.aref, actual.aref);
                 Assert.AreEqual(expected.name, actual.name);
                 Assert.AreEqual(expected.connections, actual.connections);
-            
+
+        }
+
+        //FIXME: make F# quotations and Async serializable
+        //[TestMethod]
+        public void CanSerializeQuotation()
+        {
+            var expected = TestQuotations.Quotation;
+            Serialize(expected);
+            Reset();
+            var actual = Deserialize<FSharpExpr<FSharpFunc<int, FSharpAsync<int>>>>();
+            // Assert.AreEqual(expected, actual);
+            Assert.AreEqual(expected, actual);
         }
     }
 }

--- a/Wire.Tests/Wire.Tests.csproj
+++ b/Wire.Tests/Wire.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="CustomObjectTests.cs" />
     <Compile Include="CyclicTests.cs" />
     <Compile Include="DelegateTests.cs" />
+    <Compile Include="ExpressionTests.cs" />
     <Compile Include="FSharpTests.cs" />
     <Compile Include="IlCompilerTests.cs" />
     <Compile Include="ImmutableCollectionsTests.cs" />

--- a/Wire/SerializerFactories/ConstructorInfoSerializerFactory.cs
+++ b/Wire/SerializerFactories/ConstructorInfoSerializerFactory.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+using Wire.Extensions;
+using Wire.ValueSerializers;
+
+namespace Wire.SerializerFactories
+{
+    public class ConstructorInfoSerializerFactory : ValueSerializerFactory
+    {
+        public override bool CanSerialize(Serializer serializer, Type type)
+        {
+            return type.GetTypeInfo().IsSubclassOf(typeof(ConstructorInfo));
+        }
+
+        public override bool CanDeserialize(Serializer serializer, Type type)
+        {
+            return CanSerialize(serializer, type);
+        }
+
+        public override ValueSerializer BuildSerializer(Serializer serializer, Type type,
+            ConcurrentDictionary<Type, ValueSerializer> typeMapping)
+        {
+            var os = new ObjectSerializer(type);
+            typeMapping.TryAdd(type, os);
+            ObjectReader reader = (stream, session) =>
+            {
+                var owner = stream.ReadObject(session) as Type;
+                var arguments = stream.ReadObject(session) as Type[];
+
+#if NET45
+                var ctor = owner.GetTypeInfo().GetConstructor(arguments);
+                return ctor;
+#else
+                return null;
+#endif
+            };
+            ObjectWriter writer = (stream, obj, session) =>
+            {
+                var ctor = (ConstructorInfo)obj;
+                var owner = ctor.DeclaringType;
+                var arguments = ctor.GetParameters().Select(p => p.ParameterType).ToArray();
+                stream.WriteObjectWithManifest(owner, session);
+                stream.WriteObjectWithManifest(arguments, session);
+            };
+            os.Initialize(reader, writer);
+
+            return os;
+        }
+    }
+}

--- a/Wire/SerializerFactories/EnumerableSerializerFactory.cs
+++ b/Wire/SerializerFactories/EnumerableSerializerFactory.cs
@@ -15,7 +15,7 @@ namespace Wire.SerializerFactories
         {
             //TODO: check for constructor with IEnumerable<T> param
 
-            if (type.GetTypeInfo().GetMethod("AddRange") == null && type.GetTypeInfo().GetMethod("Add") == null)
+            if (!type.GetTypeInfo().GetMethods().Any(m => m.Name == "AddRange" || m.Name == "Add"))
                 return false;
 
             if (type.GetTypeInfo().GetProperty("Count") == null)

--- a/Wire/SerializerFactories/FieldInfoSerializerFactory.cs
+++ b/Wire/SerializerFactories/FieldInfoSerializerFactory.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using Wire.Extensions;
+using Wire.ValueSerializers;
+
+namespace Wire.SerializerFactories
+{
+    public class FieldInfoSerializerFactory : ValueSerializerFactory
+    {
+        public override bool CanSerialize(Serializer serializer, Type type)
+        {
+            return type.GetTypeInfo().IsSubclassOf(typeof(FieldInfo));
+        }
+
+        public override bool CanDeserialize(Serializer serializer, Type type)
+        {
+            return CanSerialize(serializer, type);
+        }
+
+        public override ValueSerializer BuildSerializer(Serializer serializer, Type type,
+            ConcurrentDictionary<Type, ValueSerializer> typeMapping)
+        {
+            var os = new ObjectSerializer(type);
+            typeMapping.TryAdd(type, os);
+            ObjectReader reader = (stream, session) =>
+            {
+                var name = stream.ReadString(session);
+                var owner = stream.ReadObject(session) as Type;
+
+#if NET45
+                var field = owner.GetTypeInfo().GetField(name, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                return field;
+#else
+                return null;
+#endif
+            };
+            ObjectWriter writer = (stream, obj, session) =>
+            {
+                var field = (FieldInfo)obj;
+                var name = field.Name;
+                var owner = field.DeclaringType;
+                StringSerializer.WriteValueImpl(stream, name, session);
+                stream.WriteObjectWithManifest(owner, session);
+            };
+            os.Initialize(reader, writer);
+
+            return os;
+        }
+    }
+}

--- a/Wire/SerializerFactories/PropertyInfoSerializerFactory.cs
+++ b/Wire/SerializerFactories/PropertyInfoSerializerFactory.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+using Wire.Extensions;
+using Wire.ValueSerializers;
+
+namespace Wire.SerializerFactories
+{
+    public class PropertyInfoSerializerFactory : ValueSerializerFactory
+    {
+        public override bool CanSerialize(Serializer serializer, Type type)
+        {
+            return type.GetTypeInfo().IsSubclassOf(typeof(PropertyInfo));
+        }
+
+        public override bool CanDeserialize(Serializer serializer, Type type)
+        {
+            return CanSerialize(serializer, type);
+        }
+
+        public override ValueSerializer BuildSerializer(Serializer serializer, Type type,
+            ConcurrentDictionary<Type, ValueSerializer> typeMapping)
+        {
+            var os = new ObjectSerializer(type);
+            typeMapping.TryAdd(type, os);
+            ObjectReader reader = (stream, session) =>
+            {
+                var name = stream.ReadString(session);
+                var owner = stream.ReadObject(session) as Type;
+
+#if NET45
+                var property = owner.GetTypeInfo().GetProperty(name, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                return property;
+#else
+                return null;
+#endif
+            };
+            ObjectWriter writer = (stream, obj, session) =>
+            {
+                var property = (PropertyInfo)obj;
+                var name = property.Name;
+                var owner = property.DeclaringType;
+                StringSerializer.WriteValueImpl(stream, name, session);
+                stream.WriteObjectWithManifest(owner, session);
+            };
+            os.Initialize(reader, writer);
+
+            return os;
+        }
+    }
+}

--- a/Wire/SerializerOptions.cs
+++ b/Wire/SerializerOptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Wire.SerializerFactories;
+using Wire.ValueSerializers;
 
 namespace Wire
 {
@@ -13,7 +14,10 @@ namespace Wire
 
         private static readonly ValueSerializerFactory[] DefaultValueSerializerFactories =
         {
-            new MethodInfoSerializerFactory(), 
+            new MethodInfoSerializerFactory(),
+            new PropertyInfoSerializerFactory(), 
+            new ConstructorInfoSerializerFactory(),
+            new FieldInfoSerializerFactory(),
             new DelegateSerializerFactory(), 
             new ToSurrogateSerializerFactory(),
             new FromSurrogateSerializerFactory(),

--- a/Wire/Wire.csproj
+++ b/Wire/Wire.csproj
@@ -81,9 +81,11 @@
     <Compile Include="ValueSerializers\ByteSerializer.cs" />
     <Compile Include="ValueSerializers\CharSerializer.cs" />
     <Compile Include="ValueSerializers\ConsistentArraySerializer.cs" />
+    <Compile Include="SerializerFactories\ConstructorInfoSerializerFactory.cs" />
     <Compile Include="ValueSerializers\DateTimeSerializer.cs" />
     <Compile Include="ValueSerializers\DecimalSerializer.cs" />
     <Compile Include="ValueSerializers\DoubleSerializer.cs" />
+    <Compile Include="SerializerFactories\FieldInfoSerializerFactory.cs" />
     <Compile Include="ValueSerializers\FloatSerializer.cs" />
     <Compile Include="ValueSerializers\FromSurrogateSerializer.cs" />
     <Compile Include="ValueSerializers\GuidSerializer.cs" />
@@ -98,6 +100,7 @@
     <Compile Include="Serializer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SerializerSession.cs" />
+    <Compile Include="SerializerFactories\PropertyInfoSerializerFactory.cs" />
     <Compile Include="ValueSerializers\SByteSerializer.cs" />
     <Compile Include="ValueSerializers\SessionAwareByteArrayRequiringValueSerializer.cs" />
     <Compile Include="ValueSerializers\SessionIgnorantValueSerializer.cs" />

--- a/Wire/project.lock.json
+++ b/Wire/project.lock.json
@@ -3162,7 +3162,7 @@
       ]
     },
     "runtime.native.System.Net.Http/4.0.1": {
-      "sha512": "mBsKYpKLQUYz4a8NpS0VxC4DQNCcYVYOjtz9UdyVQAxL6CBRI6FBZoqwly+k1JBbcl7GZ4OS1N/xLaV5UIAteQ==",
+      "sha512": "Nh0UPZx2Vifh8r+J+H2jxifZUD3sBrmolgiFWJd2yiNrxO0xTa6bAw3YwRn1VOiSen/tUXMS31ttNItCZ6lKuA==",
       "type": "package",
       "path": "runtime.native.System.Net.Http/4.0.1",
       "files": [
@@ -4833,7 +4833,7 @@
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.1": {
-      "sha512": "tqPJ0LLLpQKsVGQqVqKe4i1KVq6m6TJjeYQLygDovNsVtyI8dWFvZC+CQQrfqo1AnbbDq/7S+TQNkOfzxNqPvw==",
+      "sha512": "sSzHHXueZ5Uh0OLpUQprhr+ZYJrLPA2Cmr4gn0wj9+FftNKXx8RIMKvO9qnjk2ebPYUjZ+F2ulGdPOsvj+MEjA==",
       "type": "package",
       "path": "System.Reflection.Emit.Lightweight/4.0.1",
       "files": [
@@ -5536,7 +5536,7 @@
       ]
     },
     "System.Security.Cryptography.Cng/4.2.0": {
-      "sha512": "k4YzVPC/8jwgmiwLGRteetYrd/qp+us5CpagrPJ5XmCj8JrwtZnD3c6wQ0Qv3kK02nc0x15vVIxp+yL4EGjAsA==",
+      "sha512": "cUJ2h+ZvONDe28Szw3st5dOHdjndhJzQ2WObDEXAWRPEQBtVItVoxbXM/OEsTthl3cNn2dk2k0I3y45igCQcLw==",
       "type": "package",
       "path": "System.Security.Cryptography.Cng/4.2.0",
       "files": [
@@ -5562,7 +5562,7 @@
       ]
     },
     "System.Security.Cryptography.Csp/4.0.0": {
-      "sha512": "RskCiZVzL8Ygo/MB4SNsNVch5fRtWyCPdpkxcIEYAPdVV7fWZW2HABm67773xUsQr+hsbQg2KN5H9RlPt0NquA==",
+      "sha512": "/i1Usuo4PgAqgbPNC0NjbO3jPW//BoBlTpcWFD1EHVbidH21y4c1ap5bbEMSGAXjAShhMH4abi/K8fILrnu4BQ==",
       "type": "package",
       "path": "System.Security.Cryptography.Csp/4.0.0",
       "files": [
@@ -5631,7 +5631,7 @@
       ]
     },
     "System.Security.Cryptography.OpenSsl/4.0.0": {
-      "sha512": "tINzoEUUUftkzGRK17WhXpx9W6ntHQqpgUg80pnR03Ix+vbME7s4BBV7AykYn2HNq6x8TelCJQ7wgX0p3y6ozg==",
+      "sha512": "HUG/zNUJwEiLkoURDixzkzZdB5yGA5pQhDP93ArOpDPQMteURIGERRNzzoJlmTreLBWr5lkFSjjMSk8ySEpQMw==",
       "type": "package",
       "path": "System.Security.Cryptography.OpenSsl/4.0.0",
       "files": [


### PR DESCRIPTION
This PR introduces fixes and serialization factories necessary to serialize reflection types like `ConstructorInfo`, `PropertyInfo`, `FieldInfo` and C# LINQ expressions - at least most of them, as I don't suppose that C# `dynamic` is supported. 

Additionally PR contains test suite for most common expressions and test for F# quotation - latter is skipped, as Wire is unable to pass this test at the moment. This can be done in a separate PR.
