### PR TITLE
Fix replacing Version in TypeEx for GetShortAssemblyQualifiedName

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,2 @@
+#### 0.8.3 - 20.04.2017
+* BUGFIX: Fix replacing Version in TypeEx for GetShortAssemblyQualifiedName - usable, when you need to write unit tests for serializer and your build server does assebly version patching (result is different byte array produced by serializer on the server then on developers local environment)

--- a/Wire.Tests/Extensions/TypeExTests.cs
+++ b/Wire.Tests/Extensions/TypeExTests.cs
@@ -1,0 +1,21 @@
+﻿using Wire.Extensions;
+using Xunit;
+
+namespace Wire.Tests.Extensions
+{
+    public class TypeExTests
+    {
+        [Theory]
+        [InlineData("Wire.Tests.Extensions.TypeExTests+FakeEntity, Wire.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null")]
+        [InlineData("Wire.Tests.Extensions.TypeExTests+FakeEntity, Wire.Tests, Version=1.3.9, Culture=neutral, PublicKeyToken=null")]
+        [InlineData("Wire.Tests.Extensions.TypeExTests+FakeEntity, Wire.Tests, Version=1.666.32323232323.32232, Culture=neutral, PublicKeyToken=null")]
+        [InlineData("Wire.Tests.Extensions.TypeExTests+FakeEntity, Wire.Tests, Version=1, Culture=neutral, PublicKeyToken=null")]
+        [InlineData("Wire.Tests.Extensions.TypeExTests+FakeEntity, Wire.Tests, Version=1.0, Culture=neutral, PublicKeyToken=null")]
+        [InlineData("Wire.Tests.Extensions.TypeExTests+FakeEntity, Wire.Tests")]
+        public void ShouldRemoveVersionFromAssemblyQualifiedName(string input)
+        {
+            var result = TypeEx.ReplaceTokens(input);
+            Assert.Equal("Wire.Tests.Extensions.TypeExTests+FakeEntity, Wire.Tests", result);
+        }
+    }
+}

--- a/Wire.Tests/Wire.Tests.csproj
+++ b/Wire.Tests/Wire.Tests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="CyclicTests.cs" />
     <Compile Include="DelegateTests.cs" />
     <Compile Include="ExpressionTests.cs" />
+    <Compile Include="Extensions\TypeExTests.cs" />
     <Compile Include="FSharpTests.cs" />
     <Compile Include="IlCompilerTests.cs" />
     <Compile Include="ImmutableCollectionsTests.cs" />

--- a/Wire/Extensions/TypeEx.cs
+++ b/Wire/Extensions/TypeEx.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 #if SERIALIZATION
 using System.Runtime.Serialization;
 
@@ -19,6 +20,7 @@ namespace Wire.Extensions
 {
     public static class TypeEx
     {
+        const string VERSION_REGEX = @", Version=(\d+([.]\d+)?([.]\d+)?([.]\d+)?.*?)";
         //Why not inline typeof you ask?
         //Because it actually generates calls to get the type.
         //We prefetch all primitives here
@@ -207,17 +209,29 @@ namespace Wire.Extensions
         public static string GetShortAssemblyQualifiedName(this Type self)
         {
             var name = self.AssemblyQualifiedName;
-            name = name.Replace(CoreAssemblyName, ",%core%");
-            name = name.Replace(", Culture=neutral", "");
-            name = name.Replace(", PublicKeyToken=null", "");
-            name = name.Replace(", Version=1.0.0.0", ""); //TODO: regex or whatever...
-            return name;
+            return ReplaceTokens(name);
         }
 
         public static string ToQualifiedAssemblyName(string shortName)
         {
             var res = shortName.Replace(",%core%", CoreAssemblyName);
             return res;
+        }
+
+        public static string ReplaceTokens(string input)
+        {
+            var name = input;
+            name = name.Replace(CoreAssemblyName, ",%core%");
+            name = name.Replace(", Culture=neutral", "");
+            name = name.Replace(", PublicKeyToken=null", "");
+            name = ReplaceVersion(name);
+            return name;
+        }
+
+        static string ReplaceVersion(string input)
+        {
+            var regex = new Regex(VERSION_REGEX);
+            return regex.Replace(input, "");
         }
     }
 }


### PR DESCRIPTION
Usable, when you need to write unit tests for serializer and your build server does assebly version patching (result is different byte array produced by serializer on the server then on developers local environment)